### PR TITLE
add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'software bug'
+labels: issue/bug, issue/not-assign
+assignees: 'erikjiang'
+
+---
+
+**Describe the version**
+version about:
+1. kubean
+2. kubespray
+3. kubenetes
+4. what CNI and itsversion
+
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**How To Reproduce**
+Steps to reproduce the issue:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots and log**
+If applicable, add screenshots and log to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/ci-failure.md
+++ b/.github/ISSUE_TEMPLATE/ci-failure.md
@@ -1,0 +1,18 @@
+---
+name: CI failure
+about: Create a report to help us improve
+title: 'CI failure'
+labels: issue/ci-fail, issue/not-assign
+assignees: 'erikjiang'
+
+---
+
+Set title to be in the format CI: <test-name>.
+
+Copy-paste the output the test failure.
+
+Upload the zip file generated from that test failure.
+
+Copy-paste the link of the CI build where that test failure has happen.
+
+Include any output from logs that you think may be relevant (to ease GitHub searches).

--- a/.github/ISSUE_TEMPLATE/doc.md
+++ b/.github/ISSUE_TEMPLATE/doc.md
@@ -1,0 +1,12 @@
+---
+name: Documentation issue
+about: documentation is not right
+title: 'documentation issue'
+labels: issue/doc, issue/not-assign
+assignees: 'erikjiang'
+
+---
+
+**Documentation issue**
+1. miss documentation
+2. documentation go wrong

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,40 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'feature'
+labels: issue/feature, issue/not-assign
+assignees: 'erikjiang'
+
+---
+
+**1 Code requirement**
+
+necessary comment for your additional code , and comment for goDoc
+
+function and variable name must not be at will
+
+do not make huge function
+
+**2 observe opensource license**
+
+announce license at the beginning of file
+
+**3 sign-off your commit**
+
+your commit must be signed off
+
+**4 Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**5 Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**6 Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**7 Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/usage.md
+++ b/.github/ISSUE_TEMPLATE/usage.md
@@ -1,0 +1,11 @@
+---
+name: usage issue
+about: no idea how to use
+title: 'usage issue'
+labels: issue/usage, issue/not-assign
+assignees: 'erikjiang'
+
+---
+
+**usage issue**
+1. doubts about how to use the software


### PR DESCRIPTION
Signed-off-by: bo.jiang <bo.jiang@daocloud.io>

Added GitHub issue template to make issue creation more standardized.