### PR TITLE
 Verify upgrade from v1.23 to v1.24 and clusterops backoff limit

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -63,11 +63,6 @@ sed -i "s#  \"10.6.170.10:5000\": \"http://10.6.170.10:5000\"#   - 10.6.170.10:5
 # override_system_hostname=false
 sed -i "$ a\    override_system_hostname: false" $(pwd)/test/kubean_functions_e2e/e2e-install-cluster-docker/vars-conf-cm.yml
 
-# prepare kubean ops yml
-cp $(pwd)/test/common/kubeanCluster.yml $(pwd)/test/kubeanOps_functions_e2e/e2e-install-cluster/
-cp $(pwd)/test/common/vars-conf-cm.yml $(pwd)/test/kubeanOps_functions_e2e/e2e-install-cluster/
-
-# Run nightly e2e
+# Run cluster function e2e
 ginkgo -v -race --fail-fast ./test/kubean_deploy_e2e/  -- --kubeconfig="${MAIN_KUBECONFIG}"
 ginkgo -v -race --fail-fast ./test/kubean_functions_e2e/  -- --kubeconfig="${MAIN_KUBECONFIG}" --vmipaddr="${vm_ip_addr}"
-ginkgo -v -race --fail-fast ./test/kubeanOps_functions_e2e/  -- --kubeconfig="${MAIN_KUBECONFIG}" --vmipaddr="${vm_ip_addr}"

--- a/hack/run-sonobouy-e2e.sh
+++ b/hack/run-sonobouy-e2e.sh
@@ -65,12 +65,28 @@ sed -i "s/containerd/docker/" $(pwd)/test/kubean_sonobouy_e2e/e2e-install-cluste
 sed -i "s/v1.23.7/v1.22.12/" $(pwd)/test/kubean_sonobouy_e2e/e2e-install-cluster-sonobouy/vars-conf-cm.yml
 sed -i "s#  \"10.6.170.10:5000\": \"http://10.6.170.10:5000\"#   - 10.6.170.10:5000#" $(pwd)/test/kubean_sonobouy_e2e/e2e-install-cluster-sonobouy/vars-conf-cm.yml
 
-# prepare cluster upgrade job yml
+# prepare cluster upgrade job yml --> upgrade from v1.22.12 to v1.23.7
 mkdir $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster
 cp $(pwd)/test/kubean_sonobouy_e2e/e2e-install-cluster-sonobouy/* $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster/
 sed -i "s/v1.22.12/v1.23.7/" $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster/vars-conf-cm.yml
 sed -i "s/e2e-cluster1-install-sonobouy/e2e-upgrade-cluster/" $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster/kubeanClusterOps.yml
 sed -i "s/cluster.yml/upgrade-cluster.yml/" $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster/kubeanClusterOps.yml
 
+# prepare cluster upgrade job yml --> upgrade from v1.23.7 to v1.24.3
+mkdir $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster24
+cp $(pwd)/test/kubean_sonobouy_e2e/e2e-install-cluster-sonobouy/* $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster24/
+sed -i "s/v1.22.12/v1.24.3/" $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster24/vars-conf-cm.yml
+sed -i "s/e2e-cluster1-install-sonobouy/e2e-upgrade-cluster24/" $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster24/kubeanClusterOps.yml
+sed -i "s/cluster.yml/upgrade-cluster.yml/" $(pwd)/test/kubean_sonobouy_e2e/e2e-upgrade-cluster24/kubeanClusterOps.yml
+
 # Run nightly e2e
-ginkgo -v -race --fail-fast ./test/kubean_sonobouy_e2e/  -- --kubeconfig="${MAIN_KUBECONFIG}" --vmipaddr="${vm_ip_addr1}" --vmipaddr2="${vm_ip_addr2}" 
+ginkgo -v -race --fail-fast ./test/kubean_sonobouy_e2e/  -- --kubeconfig="${MAIN_KUBECONFIG}" --vmipaddr="${vm_ip_addr1}" --vmipaddr2="${vm_ip_addr2}"
+
+# prepare kubean ops yml
+cp $(pwd)/test/common/kubeanCluster.yml $(pwd)/test/kubeanOps_functions_e2e/e2e-install-cluster/
+cp $(pwd)/test/common/vars-conf-cm.yml $(pwd)/test/kubeanOps_functions_e2e/e2e-install-cluster/
+cp $(pwd)/test/common/kubeanCluster.yml $(pwd)/test/kubeanOps_functions_e2e/backofflimit-clusterops/
+sed -i "s/cluster1/cluster2/" $(pwd)/test/kubeanOps_functions_e2e/backofflimit-clusterops/kubeanCluster.yml
+cp $(pwd)/test/common/vars-conf-cm.yml $(pwd)/test/kubeanOps_functions_e2e/backofflimit-clusterops/
+sed -i "s/cluster1/cluster2/" $(pwd)/test/kubeanOps_functions_e2e/backofflimit-clusterops/vars-conf-cm.yml
+ginkgo -v -race --fail-fast ./test/kubeanOps_functions_e2e/  -- --kubeconfig="${MAIN_KUBECONFIG}" --vmipaddr="${vm_ip_addr1}"

--- a/test/common/vars-conf-cm.yml
+++ b/test/common/vars-conf-cm.yml
@@ -25,6 +25,9 @@ data:
     kube_service_addresses: 10.96.0.0/12
     kube_pods_subnet: 192.168.128.0/20
     kube_network_node_prefix: 24
+
+    calico_cni_name: calico
+    calico_felix_premetheusmetricsenabled: true
  
     # Download Config
     download_run_once: true

--- a/test/kubeanOps_functions_e2e/backofflimit-clusterops/hosts-conf-cm.yml
+++ b/test/kubeanOps_functions_e2e/backofflimit-clusterops/hosts-conf-cm.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster2-hosts-conf
+  namespace: kubean-system
+data:
+  hosts.yml: ""

--- a/test/kubeanOps_functions_e2e/backofflimit-clusterops/kubeanClusterOps.yml
+++ b/test/kubeanOps_functions_e2e/backofflimit-clusterops/kubeanClusterOps.yml
@@ -1,0 +1,13 @@
+apiVersion: kubeanclusterops.kubean.io/v1alpha1
+kind: KuBeanClusterOps
+metadata:
+  name: backofflimit0-clusterops-test
+  labels:
+    clusterName: cluster2
+spec:
+  kuBeanCluster: cluster2
+  image: ghcr.io/kubean-io/kubean/spray-job:latest
+  backoffLimit: 0
+  actionType: shell
+  action: |
+    中文命令

--- a/test/kubeanOps_functions_e2e/kubean_bol0_test.go
+++ b/test/kubeanOps_functions_e2e/kubean_bol0_test.go
@@ -1,0 +1,42 @@
+package kubeanOps_functions_e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/kubean-io/kubean/test/tools"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var _ = ginkgo.Describe("kubean ops e2e test backofflimit=0", func() {
+	config, err := clientcmd.BuildConfigFromFlags("", tools.Kubeconfig)
+	gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
+	kubeanNamespace := "kubean-system"
+
+	ginkgo.Context("when installation fail then retry, set backofflimit=0", func() {
+		kubeanClusterOpsName := "backofflimit0-clusterops-test"
+		clusterInstallYamlsPath := "backofflimit-clusterops"
+		installYamlPath := fmt.Sprint(tools.GetKuBeanPath(), clusterInstallYamlsPath)
+		cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", installYamlPath)
+		out, _ := tools.DoCmd(*cmd)
+		fmt.Println("backofflimit=0 kubeanclusterops: ", out.String())
+		time.Sleep(100 * time.Second)
+		kubeClient, err := kubernetes.NewForConfig(config)
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed new client set")
+		pods, _ := kubeClient.CoreV1().Pods(kubeanNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("job-name=kubean-%s-job", kubeanClusterOpsName),
+		})
+		fmt.Println(len(pods.Items))
+
+		ginkgo.It("there is 1 kubeanclusterops related pod", func() {
+			gomega.Expect(len(pods.Items)).Should(gomega.BeNumerically("==", 1))
+		})
+	})
+
+})

--- a/test/kubeanOps_functions_e2e/kubean_bol1_test.go
+++ b/test/kubeanOps_functions_e2e/kubean_bol1_test.go
@@ -1,0 +1,50 @@
+package kubeanOps_functions_e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/kubean-io/kubean/test/tools"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var _ = ginkgo.Describe("kubean ops e2e test backofflimit=1", func() {
+	config, err := clientcmd.BuildConfigFromFlags("", tools.Kubeconfig)
+	gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
+	var _, currentFile, _, _ = runtime.Caller(0)
+	var basepath = filepath.Dir(currentFile)
+	kubeanNamespace := "kubean-system"
+
+	ginkgo.Context("when installation fail then retry, set backofflimit=1", func() {
+		opsFile := filepath.Join(basepath, "/backofflimit-clusterops/kubeanClusterOps.yml")
+		kubeanClusterOpsNewName := "backofflimit1-clusterops-test"
+		tools.UpdateOpsYml(kubeanClusterOpsNewName, opsFile)
+		tools.UpdateBackoffLimit(1, opsFile)
+
+		clusterInstallYamlsPath := "backofflimit-clusterops"
+		installYamlPath := fmt.Sprint(tools.GetKuBeanPath(), clusterInstallYamlsPath)
+		cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", installYamlPath)
+		out, _ := tools.DoCmd(*cmd)
+		fmt.Println("backofflimit=1 kubeanclusterOps: ", out.String())
+		time.Sleep(150 * time.Second)
+		kubeClient, err := kubernetes.NewForConfig(config)
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed new client set")
+		pods, _ := kubeClient.CoreV1().Pods(kubeanNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("job-name=kubean-%s-job", kubeanClusterOpsNewName),
+		})
+		fmt.Println(len(pods.Items))
+
+		ginkgo.It("there is 2 kubeanclusterops related pod", func() {
+			gomega.Expect(len(pods.Items)).Should(gomega.BeNumerically("==", 2))
+		})
+	})
+
+})

--- a/test/kubeanOps_functions_e2e/kubean_bol2_test.go
+++ b/test/kubeanOps_functions_e2e/kubean_bol2_test.go
@@ -1,0 +1,50 @@
+package kubeanOps_functions_e2e
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/kubean-io/kubean/test/tools"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var _ = ginkgo.Describe("kubean ops e2e test for backofflimit=2", func() {
+	config, err := clientcmd.BuildConfigFromFlags("", tools.Kubeconfig)
+	gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
+	var _, currentFile, _, _ = runtime.Caller(0)
+	var basepath = filepath.Dir(currentFile)
+	kubeanNamespace := "kubean-system"
+
+	ginkgo.Context("when installation fail then retry, set backofflimit=2", func() {
+		opsFile := filepath.Join(basepath, "/backofflimit-clusterops/kubeanClusterOps.yml")
+		kubeanClusterOpsNewName := "backofflimit2-clusterops-test"
+		tools.UpdateOpsYml(kubeanClusterOpsNewName, opsFile)
+		tools.UpdateBackoffLimit(2, opsFile)
+
+		clusterInstallYamlsPath := "backofflimit-clusterops"
+		installYamlPath := fmt.Sprint(tools.GetKuBeanPath(), clusterInstallYamlsPath)
+		cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", installYamlPath)
+		out, _ := tools.DoCmd(*cmd)
+		fmt.Println("backoffLimit=2 kubeanclusterOps: ", out.String())
+		time.Sleep(150 * time.Second)
+		kubeClient, err := kubernetes.NewForConfig(config)
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed new client set")
+		pods, _ := kubeClient.CoreV1().Pods(kubeanNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("job-name=kubean-%s-job", kubeanClusterOpsNewName),
+		})
+		fmt.Println(len(pods.Items))
+
+		ginkgo.It("there is 3 kubeanclusterops related pod", func() {
+			gomega.Expect(len(pods.Items)).Should(gomega.BeNumerically("==", 3))
+		})
+	})
+
+})

--- a/test/kubean_sonobouy_e2e/kubean_cluster_sonobouy_test.go
+++ b/test/kubean_sonobouy_e2e/kubean_cluster_sonobouy_test.go
@@ -150,8 +150,8 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 			gomega.Expect(out2.String()).Should(gomega.ContainSubstring("1"))
 		})
 
-		masterCmd = exec.Command("sshpass", "-p", "root", "ssh", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", masterSSH, "cat", "/proc/sys/net/ipv4/tcp_tw_recycle")
-		workerCmd = exec.Command("sshpass", "-p", "root", "ssh", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", workerSSH, "cat", "/proc/sys/net/ipv4/tcp_tw_recycle")
+		masterCmd = exec.Command("sshpass", "-p", "root", "ssh", masterSSH, "cat", "/proc/sys/net/ipv4/tcp_tw_recycle")
+		workerCmd = exec.Command("sshpass", "-p", "root", "ssh", workerSSH, "cat", "/proc/sys/net/ipv4/tcp_tw_recycle")
 		out3, _ := tools.DoCmd(*masterCmd)
 		fmt.Println("out: ", out3.String())
 		ginkgo.It("master net.ipv4.tcp_tw_recycle result checking: ", func() {
@@ -164,7 +164,7 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 		})
 	})
 
-	// cluster upgrade
+	// cluster upgrade from v1.22.12 to v1.23.7
 	ginkgo.Context("do cluster upgrade from v1.22.12 to v1.23.7", func() {
 		clusterInstallYamlsPath := "e2e-upgrade-cluster"
 		kubeanNamespace := "kubean-system"
@@ -203,9 +203,8 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 	})
 
 	time.Sleep(1 * time.Minute)
-
-	// check kube version after upgrade
-	ginkgo.Context("When fetching kube-system pods status after upgrade", func() {
+	// check kube pods status after upgrade from v1.22.12 to v1.23.7
+	ginkgo.Context("When fetching kube-system pods status after upgrade from v1.22.12 to v1.23.7", func() {
 		config, err = clientcmd.BuildConfigFromFlags("", localKubeConfigPath)
 		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
 		kubeClient, err = kubernetes.NewForConfig(config)
@@ -215,10 +214,10 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 		for _, pod := range podList.Items {
 			for {
 				po, _ := kubeClient.CoreV1().Pods("kube-system").Get(context.Background(), pod.Name, metav1.GetOptions{})
-				ginkgo.GinkgoWriter.Printf("* wait for kube-system pod[%s] status: %s\n", po.Name, po.Status.Phase)
+				ginkgo.GinkgoWriter.Printf("* wait for upgrade job from v1.22.12 to v1.23.7 related pod[%s] status: %s\n", po.Name, po.Status.Phase)
 				podStatus := string(po.Status.Phase)
 				if podStatus == "Running" || podStatus == "Failed" {
-					ginkgo.It("every pod in kube-system after upgrade should be in running status", func() {
+					ginkgo.It("every pod in kube-system after upgrade from v1.22.12 to v1.23.7 should be in running status", func() {
 						gomega.Expect(podStatus).To(gomega.Equal("Running"))
 					})
 					break
@@ -227,8 +226,8 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 			}
 		}
 	})
-
-	ginkgo.Context("check kube version after upgrade", func() {
+	// check kube version after upgrade from v1.22.12 to v1.23.7
+	ginkgo.Context("check kube version after upgrade from v1.22.12 to v1.23.7", func() {
 		config, err = clientcmd.BuildConfigFromFlags("", localKubeConfigPath)
 		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
 		kubeClient, err = kubernetes.NewForConfig(config)
@@ -238,6 +237,83 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 			ginkgo.It("kube node version should be v1.23.7", func() {
 				gomega.Expect(node.Status.NodeInfo.KubeletVersion).To(gomega.Equal("v1.23.7"))
 				gomega.Expect(node.Status.NodeInfo.KubeProxyVersion).To(gomega.Equal("v1.23.7"))
+			})
+		}
+	})
+
+	// cluster upgrade from v1.23.7 to v1.24.3
+	ginkgo.Context("do cluster upgrade from from v1.23.7 to v1.24.3", func() {
+		clusterInstallYamlsPath := "e2e-upgrade-cluster24"
+		kubeanNamespace := "kubean-system"
+		kubeanClusterOpsName := "e2e-upgrade-cluster24"
+
+		// Create yaml for kuBean CR and related configuration
+		installYamlPath := fmt.Sprint(tools.GetKuBeanPath(), clusterInstallYamlsPath)
+		cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", installYamlPath)
+		out, _ := tools.DoCmd(*cmd)
+		fmt.Println(out.String())
+
+		// Check if the job and related pods have been created
+		time.Sleep(30 * time.Second)
+		config, _ = clientcmd.BuildConfigFromFlags("", tools.Kubeconfig)
+		kubeClient, _ = kubernetes.NewForConfig(config)
+		pods, _ := kubeClient.CoreV1().Pods(kubeanNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("job-name=kubean-%s-job", kubeanClusterOpsName),
+		})
+		gomega.Expect(len(pods.Items)).NotTo(gomega.Equal(0))
+		jobPodName := pods.Items[0].Name
+
+		// Wait for job-related pod status to be succeeded
+		for {
+			pod, err := kubeClient.CoreV1().Pods(kubeanNamespace).Get(context.Background(), jobPodName, metav1.GetOptions{})
+			ginkgo.GinkgoWriter.Printf("* wait for upgrade job from v1.23.7 to v1.24.3 related pod[%s] status: %s\n", pod.Name, pod.Status.Phase)
+			gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed get job related pod")
+			podStatus := string(pod.Status.Phase)
+			if podStatus == "Succeeded" || podStatus == "Failed" {
+				ginkgo.It("cluster upgrade from v1.23.7 to v1.24.3 job related pod Status should be Succeeded", func() {
+					gomega.Expect(podStatus).To(gomega.Equal("Succeeded"))
+				})
+				break
+			}
+			time.Sleep(1 * time.Minute)
+		}
+	})
+
+	time.Sleep(1 * time.Minute)
+	// check kube pods status after upgrade from v1.23.7 to v1.24.3
+	ginkgo.Context("When fetching kube-system pods status after upgrade from v1.23.7 to v1.24.3", func() {
+		config, err = clientcmd.BuildConfigFromFlags("", localKubeConfigPath)
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
+		kubeClient, err = kubernetes.NewForConfig(config)
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed new client set")
+		podList, err := kubeClient.CoreV1().Pods("kube-system").List(context.TODO(), metav1.ListOptions{})
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed to check kube-system pod status")
+		for _, pod := range podList.Items {
+			for {
+				po, _ := kubeClient.CoreV1().Pods("kube-system").Get(context.Background(), pod.Name, metav1.GetOptions{})
+				ginkgo.GinkgoWriter.Printf("* wait for upgrade job from v1.23.7 to v1.24.3 related pod[%s] status: %s\n", po.Name, po.Status.Phase)
+				podStatus := string(po.Status.Phase)
+				if podStatus == "Running" || podStatus == "Failed" {
+					ginkgo.It("every pod in kube-system after upgrade from v1.23.7 to v1.24.3 should be in running status", func() {
+						gomega.Expect(podStatus).To(gomega.Equal("Running"))
+					})
+					break
+				}
+				time.Sleep(1 * time.Minute)
+			}
+		}
+	})
+	// check kube version after upgrade from v1.23.7 to v1.24.3
+	ginkgo.Context("check kube version after upgrade from v1.23.7 to v1.24.3", func() {
+		config, err = clientcmd.BuildConfigFromFlags("", localKubeConfigPath)
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
+		kubeClient, err = kubernetes.NewForConfig(config)
+		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed new client set")
+		nodeList, _ := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		for _, node := range nodeList.Items {
+			ginkgo.It("kube node version should be v1.24.3", func() {
+				gomega.Expect(node.Status.NodeInfo.KubeletVersion).To(gomega.Equal("v1.24.3"))
+				gomega.Expect(node.Status.NodeInfo.KubeProxyVersion).To(gomega.Equal("v1.24.3"))
 			})
 		}
 	})

--- a/test/tools/utils.go
+++ b/test/tools/utils.go
@@ -55,6 +55,21 @@ func UpdateOpsYml(content string, filePath string) {
 	_ = ioutil.WriteFile(filePath, data, 0777)
 }
 
+func UpdateBackoffLimit(content int, filePath string) {
+	// read in Ops yaml file content
+	yamlfileCotent, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		log.Fatal("fail to read insight yml file: ", err)
+	}
+	var kubeanOpsYml KubeanOpsYml
+	_ = yaml.Unmarshal(yamlfileCotent, &kubeanOpsYml)
+	// modify BackoffLimit
+	kubeanOpsYml.Spec.BackoffLimit = content
+	data, _ := yaml.Marshal(kubeanOpsYml)
+	// write back to yml file
+	_ = ioutil.WriteFile(filePath, data, 0777)
+}
+
 func DoCmd(cmd exec.Cmd) (bytes.Buffer, bytes.Buffer) {
 	ginkgo.GinkgoWriter.Printf("cmd: %s\n", cmd.String())
 	var out, stderr bytes.Buffer


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
/kind feature
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:
backofflimit=0
backofflimit=1
backofflimit=2
kube_version=1.24
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

