### PR TITLE
change hasmodified

### DIFF
--- a/test/kubeanOps_functions_e2e/kubeanOps_test.go
+++ b/test/kubeanOps_functions_e2e/kubeanOps_test.go
@@ -1,7 +1,6 @@
 package kubeanOps_functions_e2e
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
@@ -24,22 +23,15 @@ var _ = ginkgo.Describe("kubean ops e2e test", func() {
 	var basepath = filepath.Dir(currentFile)
 	clusterInstallYamlsPath := "e2e-install-cluster"
 	opsFile := filepath.Join(basepath, "/e2e-install-cluster/kubeanClusterOps.yml")
-	clusterClientOpsSet, err := kubeanClusterOpsClientSet.NewForConfig(config)
-	var out, stderr bytes.Buffer
+	clusterClientOpsSet, _ := kubeanClusterOpsClientSet.NewForConfig(config)
 
 	ginkgo.Context("when apply two jobs for one cluster hosts", func() {
 		// step1 create the first ops
 		clusterOpsName := "e2e-cluster1-ops-1st"
 		tools.UpdateOpsYml(clusterOpsName, opsFile)
 		cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", clusterInstallYamlsPath)
-		ginkgo.GinkgoWriter.Printf("cmd: %s\n", cmd.String())
-		cmd.Stdout = &out
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
-			ginkgo.GinkgoWriter.Printf("apply cmd error: %s\n", err.Error())
-			gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), stderr.String())
-		}
-		gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed new client set")
+		out, _ := tools.DoCmd(*cmd)
+		fmt.Println(out.String())
 		for {
 			clusterOps, _ := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), clusterOpsName, metav1.GetOptions{})
 			status := string(clusterOps.Status.Status)
@@ -58,13 +50,8 @@ var _ = ginkgo.Describe("kubean ops e2e test", func() {
 		clusterOpsNameSecond := "e2e-cluster1-ops-second"
 		tools.UpdateOpsYml(clusterOpsNameSecond, opsFile)
 		cmd = exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", clusterInstallYamlsPath)
-		ginkgo.GinkgoWriter.Printf("cmd: %s\n", cmd.String())
-		cmd.Stdout = &out
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
-			ginkgo.GinkgoWriter.Printf("apply cmd error: %s\n", err.Error())
-			gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), stderr.String())
-		}
+		out, _ = tools.DoCmd(*cmd)
+		fmt.Println(out.String())
 		for {
 			clusterOpsSecond, _ := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), clusterOpsNameSecond, metav1.GetOptions{})
 			statusSecond := string(clusterOpsSecond.Status.Status)
@@ -92,12 +79,8 @@ var _ = ginkgo.Describe("kubean ops e2e test", func() {
 			clusterOpsName := fmt.Sprintf("e2e-cluster1-ops-copies%d", num)
 			tools.UpdateOpsYml(clusterOpsName, opsFile)
 			cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", clusterInstallYamlsPath)
-			ginkgo.GinkgoWriter.Printf("cmd: %s\n", cmd.String())
-			cmd.Stdout = &out
-			cmd.Stderr = &stderr
-			if err := cmd.Run(); err != nil {
-				gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), stderr.String())
-			}
+			out, _ := tools.DoCmd(*cmd)
+			fmt.Println(out.String())
 			time.Sleep(10 * time.Second)
 		}
 		// step2 check cluster1 should exists 5 ops
@@ -111,11 +94,8 @@ var _ = ginkgo.Describe("kubean ops e2e test", func() {
 		clusterOpsName1 := "e2e-cluster1-ops-copies6"
 		tools.UpdateOpsYml(clusterOpsName1, opsFile)
 		cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", clusterInstallYamlsPath)
-		cmd.Stdout = &out
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
-			gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), stderr.String())
-		}
+		out, _ := tools.DoCmd(*cmd)
+		fmt.Println(out.String())
 		// step4 check the oldest ops is removed
 		for {
 			_, err := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), "e2e-cluster1-ops-copies1", metav1.GetOptions{})
@@ -125,6 +105,62 @@ var _ = ginkgo.Describe("kubean ops e2e test", func() {
 				fmt.Println("cluster1 the oldest clusterOps: ", err)
 				gomega.Expect(err).ShouldNot(gomega.BeNil())
 				break
+			}
+		}
+
+		//delete all ops to prepare for the next testcase
+		clusterOpsList, _ = clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().List(context.Background(), metav1.ListOptions{})
+		for _, ops := range clusterOpsList.Items {
+			fmt.Println("delete cluster1 clusterOps: ", ops.Name)
+			clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Delete(context.Background(), ops.Name, metav1.DeleteOptions{})
+		}
+	})
+
+	// get KuBeanClusterOps to if validate hasModified: true
+	clusterInstallYamlsPath = "e2e-install-cluster"
+	clusterOpsName := "e2e-hasmodified-ops"
+	opsFile = filepath.Join(basepath, "/e2e-install-cluster/kubeanClusterOps.yml")
+	tools.UpdateOpsYml(clusterOpsName, opsFile)
+	ginkgo.Context("precondition: when test HasModified, one kubean job should be in running status", func() {
+		cmd := exec.Command("kubectl", "--kubeconfig="+tools.Kubeconfig, "apply", "-f", clusterInstallYamlsPath)
+		out, _ := tools.DoCmd(*cmd)
+		fmt.Println(out.String())
+		for {
+			clusterOps, _ := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), clusterOpsName, metav1.GetOptions{})
+			status := string(clusterOps.Status.Status)
+			ginkgo.GinkgoWriter.Printf("* wait for e2e-hasmodified-ops status: %s\n", status)
+			if status == "Running" {
+				ginkgo.It("e2e-hasmodified-ops should be running", func() {
+					gomega.Expect(status).To(gomega.Equal("Running"))
+				})
+				break
+			} else {
+				time.Sleep(5 * time.Second)
+			}
+		}
+	})
+	clusterOps, err := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), clusterOpsName, metav1.GetOptions{})
+	fmt.Println("before patch e2e-hasmodified-ops KuBeanClusterOps.Spec.Action: ", clusterOps.Spec.Action)
+	gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed to check e2e-hasmodified-ops KuBeanClusterOps Spec.hasModified")
+	ginkgo.Context("when fetching e2e-hasmodified-ops KuBeanClusterOps", func() {
+		clusterOps.Spec.Action = "e2e-hasmodified-ops"
+		newClusterOps, err := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Update(context.Background(), clusterOps, metav1.UpdateOptions{})
+		time.Sleep(30 * time.Second)
+		fmt.Println(newClusterOps.Spec.Action)
+		ginkgo.It("e2e-hasmodified-ops KuBeanClusterOps.Spec.Action update success", func() {
+			gomega.Expect(err).Should(gomega.BeNil())
+			gomega.Expect(string(newClusterOps.Spec.Action)).Should(gomega.ContainSubstring("e2e-hasmodified-ops"))
+		})
+		for {
+			updatedClusterOps, _ := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), clusterOpsName, metav1.GetOptions{})
+			hasModified := updatedClusterOps.Status.HasModified
+			if hasModified {
+				ginkgo.It("KuBeanClusterOps.Status.hasModified should be true", func() {
+					gomega.Expect(hasModified).Should(gomega.BeTrue())
+				})
+				break
+			} else {
+				time.Sleep(10 * time.Second)
 			}
 		}
 	})

--- a/test/kubean_functions_e2e/kubean_cluster_install_test.go
+++ b/test/kubean_functions_e2e/kubean_cluster_install_test.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	kubeanClusterClientSet "kubean.io/api/generated/kubeancluster/clientset/versioned"
-	kubeanClusterOpsClientSet "kubean.io/api/generated/kubeanclusterops/clientset/versioned"
 )
 
 var _ = ginkgo.Describe("e2e test cluster operation", func() {
@@ -207,38 +206,6 @@ var _ = ginkgo.Describe("e2e test cluster operation", func() {
 		ginkgo.It("nginx service can be request", func() {
 			gomega.Expect(out.String()).Should(gomega.ContainSubstring("Welcome to nginx!"))
 		})
-	})
-
-	// get KuBeanClusterOps to if validate hasModified: true
-	config, err = clientcmd.BuildConfigFromFlags("", tools.Kubeconfig)
-	gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed build config")
-	clusterClientOpsSet, err := kubeanClusterOpsClientSet.NewForConfig(config)
-	gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed new client set")
-	clusterOpsName := "e2e-cluster1-install"
-	clusterOps, err := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), clusterOpsName, metav1.GetOptions{})
-	fmt.Println("before patch KuBeanClusterOps.Spec.Action: ", clusterOps.Spec.Action)
-	gomega.ExpectWithOffset(2, err).NotTo(gomega.HaveOccurred(), "failed to check KuBeanClusterOps Spec.hasModified")
-	ginkgo.Context("when fetching KuBeanClusterOps", func() {
-		clusterOps.Spec.Action = "e2etest"
-		newClusterOps, err := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Update(context.Background(), clusterOps, metav1.UpdateOptions{})
-		time.Sleep(30 * time.Second)
-		fmt.Println(newClusterOps.Spec.Action)
-		ginkgo.It("KuBeanClusterOps.Spec.Action update success", func() {
-			gomega.Expect(err).Should(gomega.BeNil())
-			gomega.Expect(string(newClusterOps.Spec.Action)).Should(gomega.ContainSubstring("e2etest"))
-		})
-		for {
-			updatedClusterOps, _ := clusterClientOpsSet.KubeanclusteropsV1alpha1().KuBeanClusterOps().Get(context.Background(), clusterOpsName, metav1.GetOptions{})
-			hasModified := updatedClusterOps.Status.HasModified
-			if hasModified {
-				ginkgo.It("KuBeanClusterOps.Status.hasModified should be true", func() {
-					gomega.Expect(hasModified).Should(gomega.BeTrue())
-				})
-				break
-			} else {
-				time.Sleep(10 * time.Second)
-			}
-		}
 	})
 
 	// do cluster reset


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
/kind failing-test
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
In pre pr e2e, hasmodified checking is failed cause' such attribute is added into kubeanclusterops when one job is in running status in the latest kubean function. In the past,  hasmodified checking can do even though one job is done.
**Special notes for your reviewer**:

