### PR TITLE
Fix omitempty struct

### DIFF
--- a/api/apis/kubeaninfomanifest/v1alpha1/types.go
+++ b/api/apis/kubeaninfomanifest/v1alpha1/types.go
@@ -49,7 +49,7 @@ type LocalService struct {
 	// +optional
 	YumRepo []string `json:"yumRepo,omitempty" yaml:"yumRepo,omitempty"`
 	// +optional
-	HostsMap []HostsMap `json:"hostsMap,omitempty" yaml:"hostsMap,omitempty"`
+	HostsMap []*HostsMap `json:"hostsMap,omitempty" yaml:"hostsMap,omitempty"`
 }
 
 type HostsMap struct {

--- a/api/apis/kubeaninfomanifest/v1alpha1/zz_generated.deepcopy.go
+++ b/api/apis/kubeaninfomanifest/v1alpha1/zz_generated.deepcopy.go
@@ -176,7 +176,7 @@ func (in *LocalService) DeepCopyInto(out *LocalService) {
 	}
 	if in.HostsMap != nil {
 		in, out := &in.HostsMap, &out.HostsMap
-		*out = make([]HostsMap, len(*in))
+		*out = make([]*HostsMap, len(*in))
 		copy(*out, *in)
 	}
 	return


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug
**What this PR does / why we need it**:
it will panic when HostsMap len equal zero and k8s version less than 1.20.11, because the HostsMap's type is struct.
if not Pointer, omitempty invalidate
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
change HostsMap's type to omitempty
**Special notes for your reviewer**:

