### PR TITLE
remove the kubeconf from crd clusteroperation

### DIFF
--- a/api/apis/clusteroperation/v1alpha1/types.go
+++ b/api/apis/clusteroperation/v1alpha1/types.go
@@ -102,9 +102,6 @@ type Status struct {
 	// HasModified indicates the spec has been modified by others after created.
 	// +optional
 	HasModified bool `json:"hasModified,omitempty"`
-	// KubeConfig will be modified by the job completed successfully and operator fetch the kubeconfig of the new k8s cluster.
-	// +optional
-	KubeConfig string `json:"kubeConfig,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/charts/crds/kubean.io_clusteroperations.yaml
+++ b/api/charts/crds/kubean.io_clusteroperations.yaml
@@ -164,10 +164,6 @@ spec:
                 - name
                 - namespace
                 type: object
-              kubeConfig:
-                description: KubeConfig will be modified by the job completed successfully
-                  and operator fetch the kubeconfig of the new k8s cluster.
-                type: string
               startTime:
                 format: date-time
                 type: string

--- a/charts/kubean/crds/kubean.io_clusteroperations.yaml
+++ b/charts/kubean/crds/kubean.io_clusteroperations.yaml
@@ -164,10 +164,6 @@ spec:
                 - name
                 - namespace
                 type: object
-              kubeConfig:
-                description: KubeConfig will be modified by the job completed successfully
-                  and operator fetch the kubeconfig of the new k8s cluster.
-                type: string
               startTime:
                 format: date-time
                 type: string

--- a/vendor/kubean.io/api/apis/clusteroperation/v1alpha1/types.go
+++ b/vendor/kubean.io/api/apis/clusteroperation/v1alpha1/types.go
@@ -102,9 +102,6 @@ type Status struct {
 	// HasModified indicates the spec has been modified by others after created.
 	// +optional
 	HasModified bool `json:"hasModified,omitempty"`
-	// KubeConfig will be modified by the job completed successfully and operator fetch the kubeconfig of the new k8s cluster.
-	// +optional
-	KubeConfig string `json:"kubeConfig,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Signed-off-by: hang.jiang <hang.jiang@daocloud.io>

<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->

/kind cleanup

**What this PR does / why we need it**:

* remove useless field in CRD clusterOperation

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

