### PR TITLE
Add pause image new tag in image list

### DIFF
--- a/artifacts/generate_offline_package.sh
+++ b/artifacts/generate_offline_package.sh
@@ -18,6 +18,17 @@ function generate_offline_dir() {
   mkdir -p $OFFLINE_OSPKGS_DIR
 }
 
+function add_pause_image_addr() {
+  image_list=$1
+  pause_img_addr=$(cat ${image_list} |grep pause)
+  if [ ! -z "${pause_img_addr}" ]; then
+    pause_addr=$(echo ${pause_img_addr}|cut -d: -f1)
+    pause_tag=$(echo ${pause_img_addr}|cut -d: -f2)
+    new_tag=$(awk 'BEGIN{print '${pause_tag}+0.1' }')
+    echo "${pause_addr}:${new_tag}" >> ${image_list}
+  fi
+}
+
 function generate_temp_list() {
   if [ ! -d "kubespray" ]; then
     echo "kubespray git repo should exist."
@@ -31,7 +42,7 @@ function generate_temp_list() {
   remove_images="aws-alb|aws-ebs|cert-manager|netchecker|weave|sig-storage|external_storage|cinder-csi|kubernetesui|flannel"
   mv contrib/offline/temp/images.list contrib/offline/temp/images.list.old
   cat contrib/offline/temp/images.list.old | egrep -v ${remove_images} > contrib/offline/temp/images.list
-
+  add_pause_image_addr contrib/offline/temp/images.list
   cp contrib/offline/temp/*.list $OFFLINE_PACKAGE_DIR
 }
 


### PR DESCRIPTION
Signed-off-by: bo.jiang <bo.jiang@daocloud.io>

<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The offline deployment process reports an error, indicating that there is no new tag image for pause, so for the time being it is handled by replenishing the list of images.

```
	[WARNING FileAvailable--etc-kubernetes-kubelet.conf]: /etc/kubernetes/kubelet.conf already exists
	[WARNING Port-10250]: Port 10250 is in use
W1029 20:45:31.124568   23685 utils.go:69] The recommended value for "clusterDNS" in "KubeletConfiguration" is: [100.64.0.10]; the provided value is: [100.64.0.3]
	[WARNING Port-10259]: Port 10259 is in use
	[WARNING Port-10257]: Port 10257 is in use
	[WARNING FileAvailable--etc-kubernetes-manifests-kube-apiserver.yaml]: /etc/kubernetes/manifests/kube-apiserver.yaml already exists
	[WARNING FileAvailable--etc-kubernetes-manifests-kube-controller-manager.yaml]: /etc/kubernetes/manifests/kube-controller-manager.yaml already exists
	[WARNING FileAvailable--etc-kubernetes-manifests-kube-scheduler.yaml]: /etc/kubernetes/manifests/kube-scheduler.yaml already exists
	[WARNING ImagePull]: failed to pull image temp-registry.daocloud.io/registry.k8s.io/pause:3.8: output: E1029 20:45:31.550068   23803 remote_image.go:242] "PullImage from image service failed" err="rpc error: code = NotFound desc = failed to pull and unpack image \"temp-registry.daocloud.io/registry.k8s.io/pause:3.8\": failed to resolve reference \"temp-registry.daocloud.io/registry.k8s.io/pause:3.8\": temp-registry.daocloud.io/registry.k8s.io/pause:3.8: not found" image="temp-registry.daocloud.io/registry.k8s.io/pause:3.8"
time="2022-10-29T20:45:31+08:00" level=fatal msg="pulling image: rpc error: code = NotFound desc = failed to pull and unpack image \"temp-registry.daocloud.io/registry.k8s.io/pause:3.8\": failed to resolve reference \"temp-registry.daocloud.io/registry.k8s.io/pause:3.8\": temp-registry.daocloud.io/registry.k8s.io/pause:3.8: not found"
, error: exit status 1
{"level":"warn","ts":"2022-10-29T20:45:35.261+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fc700/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:35.388+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fc8c0/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:35.566+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000390a80/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:35.812+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000390c40/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:36.180+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000391340/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:36.737+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fcc40/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:37.515+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fd180/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:38.683+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00039b500/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:40.422+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000391180/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:43.077+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fc700/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:47.134+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fcc40/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:45:53.383+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000391340/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:46:02.229+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fc8c0/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:46:15.707+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00054ee00/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:46:35.802+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00054f180/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:47:06.376+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000391180/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:47:51.427+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00054fa40/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
{"level":"warn","ts":"2022-10-29T20:48:59.057+0800","logger":"etcd-client","caller":"v3/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0001fca80/10.6.170.51:2379","attempt":0,"error":"rpc error: code = Unknown desc = etcdserver: re-configuration failed due to not enough started members"}
error execution phase control-plane-join/etcd: error creating local etcd static pod manifest file: etcdserver: re-configuration failed due to not enough started members
To see the stack trace of this error execute with --v=5 or higher
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

