### PR TITLE
chart: namespace should go with release

### DIFF
--- a/charts/kubean/templates/_helpers.tpl
+++ b/charts/kubean/templates/_helpers.tpl
@@ -6,7 +6,7 @@ Expand the name of the chart.
 {{- end }}
 
 {{- define "kubean.namespace" -}}
-{{- default .Values.namespace -}}
+{{- .Release.Namespace -}}
 {{- end -}}
 
 {{/*

--- a/charts/kubean/values.yaml
+++ b/charts/kubean/values.yaml
@@ -11,8 +11,6 @@ global:
   ##   - myRegistryKeySecretName
   imagePullSecrets: []
 
-namespace: kubean-system
-
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Signed-off-by: weizhou.lan@daocloud.io <weizhou.lan@daocloud.io>


**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
the release namespace should go with the helm option -n, but the chart defines another variable 'namespace', make it not convenient to install 

the following will go wrong
```
# helm install kubean kubean-io/kubean -n test
```

It should go with following command, it's not helm best practice
```
# helm install kubean kubean-io/kubean -n test --set namespace=test
```

after this pr, make it right with `helm install kubean kubean-io/kubean -n test`


Fixes #


**Special notes for your reviewer**:

