### PR TITLE
Block the update repo from kylin os

### DIFF
--- a/build/os-packages/check_rebuild_pkgs.sh
+++ b/build/os-packages/check_rebuild_pkgs.sh
@@ -14,10 +14,17 @@ ORG_NAME=${ORG_NAME:-""}
 # Get Latest Git Tag
 late_tag=`git tag --sort=committerdate -l | grep -o 'v.*' | tail -1`
 # Get Previous Git Tag (the one before the latest tag)
-prev_tag=`git tag --sort=committerdate -l | grep -o 'v.*' | tail -2 | head -1)`
+prev_tag=`git tag --sort=committerdate -l | grep -o 'v.*' | tail -2 | head -1`
 
 wget -c https://raw.githubusercontent.com/${ORG_NAME}/kubean/${late_tag}/build/os-packages/packages.yml -O late_packages.yml
 wget -c https://raw.githubusercontent.com/${ORG_NAME}/kubean/${prev_tag}/build/os-packages/packages.yml -O prev_packages.yml
+
+if [ "${OS_NAME}" == "kylinv10" ]; then
+  ret=`git diff ${prev_tag} ${late_tag} build/os-packages/repos/kylin.repo`
+  if [ ! -z "$ret" ]; then
+      echo "true" && exit 0
+  fi
+fi
 
 # centos7 / kylinv10 / redhat7 / redhat8
 if [ "${OS_NAME}" == "centos7" ] || [ "${OS_NAME}" == "kylinv10" ] || [ "${OS_NAME}" == "redhat7" ] || [ "${OS_NAME}" == "redhat8" ]; then

--- a/build/os-packages/repos/kylin.repo
+++ b/build/os-packages/repos/kylin.repo
@@ -7,17 +7,10 @@ enabled = 1
 sslverify=0
 gpgcheck = 0
 
-[ks10-adv-updates]
-name = Kylin Linux Advanced Server 10 - Updates
-baseurl = http://update.cs2c.com.cn:8080/NS/V10/V10SP2/os/adv/lic/updates/$basearch/
-enabled = 1
-sslverify=0
-gpgcheck = 0
-
-## `docker-ce-3:20.10` has dependencies on `fuse-overlayfs` and `slirp4netns` packages, which require `almalinux-extras` repo. ##
-# [almalinux-extras]
-# name=Almalinux extras - $basearch
-# baseurl=http://repo.almalinux.org/almalinux/8/AppStream/$basearch/os/
+## update repo will cause device-mapper package conflict problem, so block.
+# [ks10-adv-updates]
+# name = Kylin Linux Advanced Server 10 - Updates
+# baseurl = http://update.cs2c.com.cn:8080/NS/V10/V10SP2/os/adv/lic/updates/$basearch/
 # enabled = 1
 # sslverify=0
 # gpgcheck = 0


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
![wecom-temp-437e108bba1ac572fa84f83684b69e58](https://user-images.githubusercontent.com/10629406/207355612-d4f4b694-db0c-405e-8002-65a507725d68.png)
![wecom-temp-70b79f8da8a37cb2ebc0684a6a52e5a5](https://user-images.githubusercontent.com/10629406/207355662-fc54b684-ed0e-4898-92f4-10509ae19356.png)
The device mapper package is included in both the base repo and update repo, so if you install only the package with the same name in the update repo, it will cause conflicts, so block the update repo.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubean-io/kubean/issues/398

**Special notes for your reviewer**:

