### PR TITLE
fix  nightly e2e helm version set

### DIFF
--- a/.github/workflows/e2e_schedule.yaml
+++ b/.github/workflows/e2e_schedule.yaml
@@ -90,9 +90,9 @@ jobs:
         run: |
           CONTAINER_TAG="$(git describe --tags --abbrev=8 --dirty)-e2e"
           HELM_CHART_VERSION=`echo ${CONTAINER_TAG}|awk -F "-" '{print $1 }'`
-          CONDITION_COUNT=$(echo ${CONTAINER_TAG}|grep -o '-'|wc -l)
-          if (( ${CONDITION_COUNT} >= 3 ));then
-             HELM_CHART_VERSION=`echo ${CONTAINER_TAG}|awk -F "-" '{print $1"-"$2 }'`
+          TAG_SECOND_PART=`echo ${CONTAINER_TAG}|awk  -F "-" '{print $2 }'`
+          if [[ ${TAG_SECOND_PART} =~ rc[0-9]+ ]];then 
+            HELM_CHART_VERSION=`echo ${CONTAINER_TAG}|awk -F "-" '{print $1"-"$2 }'`
           fi
           echo ${{ runner.name }}
           echo "${HELM_CHART_VERSION}" 


### PR DESCRIPTION
Signed-off-by: bell.guo <wenting.guo@daocloud.io>



**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
fix bug: when a tag is newly created, then run the nightly e2e, will fail. Because of fetched wrong helm version
