### PR TITLE
set nightly e2e and online os-compatibility-e2e to the online runner

### DIFF
--- a/.github/workflows/e2e_schedule.yaml
+++ b/.github/workflows/e2e_schedule.yaml
@@ -73,7 +73,7 @@ jobs:
 
   schedule_sonobouy_e2e:
     needs: build-push-for-e2e
-    runs-on: self-hosted
+    runs-on: [self-hosted, online]
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/os_e2e_schedule.yaml
+++ b/.github/workflows/os_e2e_schedule.yaml
@@ -73,7 +73,7 @@ jobs:
 
   schedule_os_e2e:
     needs: build-push-for-e2e
-    runs-on: self-hosted
+    runs-on: [self-hosted, online]
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Signed-off-by: bell.guo <wenting.guo@daocloud.io>

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
set nightly e2e and online os-compatibility-e2e to the online runner
