### PR TITLE
Fix incomplete ospkg cache judgment

### DIFF
--- a/build/os-packages/check_rebuild_pkgs.sh
+++ b/build/os-packages/check_rebuild_pkgs.sh
@@ -3,6 +3,8 @@
 # set -x
 set -eo pipefail
 
+echo "true" && exit
+
 # Note: 
 # This script is used to check whether the contents of the current os package are the same as the contents of the last os package. 
 # If the contents are the same, the last system package is directly downloaded without rebuilding. 
@@ -18,6 +20,8 @@ prev_tag=$(git tag --sort=committerdate -l | grep -o 'v.*' | tail -2 | head -1)
 
 late_packages_yml=$(git show "${late_tag}":build/os-packages/packages.yml)
 prev_packages_yml=$(git show "${prev_tag}":build/os-packages/packages.yml)
+
+git diff --quit "${prev_tag}" "${late_tag}" artifacts/import_ospkgs.sh || { echo "true"; exit; }
 
 if [ "${OS_NAME}" == "kylinv10" ]; then
   git diff --quiet "${prev_tag}" "${late_tag}" build/os-packages/repos/kylin.repo || { echo "true"; exit; }


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug

**What this PR does / why we need it**:
When import_ospkgs.sh changed in release processs, ospkg has not been rebuilt again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
[Line](https://github.com/kubean-io/kubean/pull/513/files#diff-d198d08cd9f1201441c2684e458b4ec171c62a2951520b61128a4ed186fd2f2eR6) will be deleted after the next release
