### PR TITLE
Remove ospkg buiding immediate exit

### DIFF
--- a/build/os-packages/check_rebuild_pkgs.sh
+++ b/build/os-packages/check_rebuild_pkgs.sh
@@ -3,8 +3,6 @@
 # set -x
 set -eo pipefail
 
-echo "true" && exit
-
 # Note: 
 # This script is used to check whether the contents of the current os package are the same as the contents of the last os package. 
 # If the contents are the same, the last system package is directly downloaded without rebuilding. 


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind cleanup

**What this PR does / why we need it**:
Once release out, ospkg buiding immediately exit could be removed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

