### PR TITLE
fix imageRepo field

### DIFF
--- a/api/apis/manifest/v1alpha1/types.go
+++ b/api/apis/manifest/v1alpha1/types.go
@@ -52,7 +52,7 @@ type ImageRepoPasswordAuth struct {
 
 type LocalService struct {
 	// +optional
-	ImageRepo map[ImageRepoType]string `json:"imageRepo" yaml:"imageRepo"`
+	ImageRepo map[ImageRepoType]string `json:"imageRepo,omitempty" yaml:"imageRepo,omitempty"`
 	// +optional
 	ImageRepoAuth []ImageRepoPasswordAuth `json:"imageRepoAuth,omitempty" yaml:"imageRepoAuth,omitempty"`
 	// +optional

--- a/vendor/kubean.io/api/apis/manifest/v1alpha1/types.go
+++ b/vendor/kubean.io/api/apis/manifest/v1alpha1/types.go
@@ -52,7 +52,7 @@ type ImageRepoPasswordAuth struct {
 
 type LocalService struct {
 	// +optional
-	ImageRepo map[ImageRepoType]string `json:"imageRepo" yaml:"imageRepo"`
+	ImageRepo map[ImageRepoType]string `json:"imageRepo,omitempty" yaml:"imageRepo,omitempty"`
 	// +optional
 	ImageRepoAuth []ImageRepoPasswordAuth `json:"imageRepoAuth,omitempty" yaml:"imageRepoAuth,omitempty"`
 	// +optional


### PR DESCRIPTION

/kind bug

**What this PR does / why we need it**:
fix spec.localService.imageRepo field, add omitempty

**Special notes for your reviewer**:
I0227 10:58:24.756617   27988 controller.go:214] InfoManifest Controller receive event kubeaninfomanifest-v0-4-4
W0227 10:58:24.795944   27988 controller.go:222] Manifest.kubean.io "manifest-global" is invalid: spec.localService.imageRepo: Invalid value: "null": spec.localService.imageRepo in body must be of type object: "null" 
