### PR TITLE
fix cluster status.conditions.startTime and endTime invalid value null

### DIFF
--- a/api/apis/cluster/v1alpha1/types.go
+++ b/api/apis/cluster/v1alpha1/types.go
@@ -59,9 +59,9 @@ type ClusterCondition struct {
 	// +optional
 	Status ClusterConditionType `json:"status"`
 	// +optional
-	StartTime *metav1.Time `json:"startTime"`
+	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// +optional
-	EndTime *metav1.Time `json:"endTime"`
+	EndTime *metav1.Time `json:"endTime,omitempty"`
 }
 
 // Status contains information about the current status of a

--- a/vendor/kubean.io/api/apis/cluster/v1alpha1/types.go
+++ b/vendor/kubean.io/api/apis/cluster/v1alpha1/types.go
@@ -59,9 +59,9 @@ type ClusterCondition struct {
 	// +optional
 	Status ClusterConditionType `json:"status"`
 	// +optional
-	StartTime *metav1.Time `json:"startTime"`
+	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// +optional
-	EndTime *metav1.Time `json:"endTime"`
+	EndTime *metav1.Time `json:"endTime,omitempty"`
 }
 
 // Status contains information about the current status of a


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
when i create  cluster cr，update cluster  status.condition error
"Cluster.kubean.io "cluster1-demo" is invalid: [status.conditions.startTime: Invalid value: "null": status.conditions.startTime in body must be of type string: "null", status.conditions.endTime: Invalid value: "null": status.conditions.endTime in body must be of type string: "null"]"

