### PR TITLE
fix clusteroperation multi field invalid value null

### DIFF
--- a/api/apis/clusteroperation/v1alpha1/types.go
+++ b/api/apis/clusteroperation/v1alpha1/types.go
@@ -42,13 +42,13 @@ type Spec struct {
 	HostsConfRef *apis.ConfigMapRef `json:"hostsConfRef"`
 	// VarsConfRef will be filled by operator when it performs backup.
 	// +optional
-	VarsConfRef *apis.ConfigMapRef `json:"varsConfRef"`
+	VarsConfRef *apis.ConfigMapRef `json:"varsConfRef,omitempty"`
 	// SSHAuthRef will be filled by operator when it performs backup.
 	// +optional
-	SSHAuthRef *apis.SecretRef `json:"sshAuthRef"`
+	SSHAuthRef *apis.SecretRef `json:"sshAuthRef,omitempty"`
 	// +optional
 	// EntrypointSHRef will be filled by operator when it renders entrypoint.sh.
-	EntrypointSHRef *apis.ConfigMapRef `json:"entrypointSHRef"`
+	EntrypointSHRef *apis.ConfigMapRef `json:"entrypointSHRef,omitempty"`
 	// +required
 	ActionType ActionType `json:"actionType"`
 	// +required
@@ -66,7 +66,7 @@ type Spec struct {
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources"`
 	// +optional
-	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds"`
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 }
 
 type HookAction struct {
@@ -93,13 +93,13 @@ type Status struct {
 	// +optional
 	Action string `json:"action"`
 	// +optional
-	JobRef *apis.JobRef `json:"jobRef"`
+	JobRef *apis.JobRef `json:"jobRef,omitempty"`
 	// +optional
 	Status OpsStatus `json:"status"`
 	// +optional
-	StartTime *metav1.Time `json:"startTime"`
+	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// +optional
-	EndTime *metav1.Time `json:"endTime"`
+	EndTime *metav1.Time `json:"endTime,omitempty"`
 	// Digest is used to avoid the change of clusterOps by others. it will be filled by operator. Do Not change this value.
 	// +optional
 	Digest string `json:"digest,omitempty"`

--- a/vendor/kubean.io/api/apis/clusteroperation/v1alpha1/types.go
+++ b/vendor/kubean.io/api/apis/clusteroperation/v1alpha1/types.go
@@ -42,13 +42,13 @@ type Spec struct {
 	HostsConfRef *apis.ConfigMapRef `json:"hostsConfRef"`
 	// VarsConfRef will be filled by operator when it performs backup.
 	// +optional
-	VarsConfRef *apis.ConfigMapRef `json:"varsConfRef"`
+	VarsConfRef *apis.ConfigMapRef `json:"varsConfRef,omitempty"`
 	// SSHAuthRef will be filled by operator when it performs backup.
 	// +optional
-	SSHAuthRef *apis.SecretRef `json:"sshAuthRef"`
+	SSHAuthRef *apis.SecretRef `json:"sshAuthRef,omitempty"`
 	// +optional
 	// EntrypointSHRef will be filled by operator when it renders entrypoint.sh.
-	EntrypointSHRef *apis.ConfigMapRef `json:"entrypointSHRef"`
+	EntrypointSHRef *apis.ConfigMapRef `json:"entrypointSHRef,omitempty"`
 	// +required
 	ActionType ActionType `json:"actionType"`
 	// +required
@@ -66,7 +66,7 @@ type Spec struct {
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources"`
 	// +optional
-	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds"`
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 }
 
 type HookAction struct {
@@ -93,13 +93,13 @@ type Status struct {
 	// +optional
 	Action string `json:"action"`
 	// +optional
-	JobRef *apis.JobRef `json:"jobRef"`
+	JobRef *apis.JobRef `json:"jobRef,omitempty"`
 	// +optional
 	Status OpsStatus `json:"status"`
 	// +optional
-	StartTime *metav1.Time `json:"startTime"`
+	StartTime *metav1.Time `json:"startTime,omitempty"`
 	// +optional
-	EndTime *metav1.Time `json:"endTime"`
+	EndTime *metav1.Time `json:"endTime,omitempty"`
 	// Digest is used to avoid the change of clusterOps by others. it will be filled by operator. Do Not change this value.
 	// +optional
 	Digest string `json:"digest,omitempty"`


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
when i create clusteroperation cr, The following error is reported：
ClusterOperation.kubean.io "cluster1-demo-ops-1" is invalid: [status.endTime: Invalid value: "null": status.endTime in body must be of type string: "null", status.jobRef: Invalid value: "null": status.jobRef in body must be of type object: "null", status.startTime: Invalid value: "null": status.startTime in body must be of type string: "null"]

ClusterOperation.kubean.io "cluster1-demo-ops-1" is invalid: [spec.activeDeadlineSeconds: Invalid value: "null": spec.activeDeadlineSeconds in body must be of type integer: "null", spec.varsConfRef: Invalid value: "null": spec.varsConfRef in body must be of type object: "null", spec.entrypointSHRef: Invalid value: "null": spec.entrypointSHRef in body must be of type object: "null", spec.sshAuthRef: Invalid value: "null": spec.sshAuthRef in body must be of type object: "null"]

ClusterOperation.kubean.io "cluster1-demo-ops-1" is invalid: [spec.varsConfRef: Invalid value: "null": spec.varsConfRef in body must be of type object: "null", spec.activeDeadlineSeconds: Invalid value: "null": spec.activeDeadlineSeconds in body must be of type integer: "null", spec.entrypointSHRef: Invalid value: "null": spec.entrypointSHRef in body must be of type object: "null", spec.sshAuthRef: Invalid value: "null": spec.sshAuthRef in body must be of type object: "null"]


