### PR TITLE
Reduce centos7 package size

### DIFF
--- a/build/os-packages/Dockerfile.centos7
+++ b/build/os-packages/Dockerfile.centos7
@@ -1,10 +1,12 @@
 FROM centos:7.9.2009 as os-centos7
 ARG OS_VERSION=7
 ARG BUILD_TOOLS="yum-utils createrepo epel-release wget"
+ARG PKGS_IN_ISO="selinux-policy-targeted policycoreutils-python iptables libcgroup libnetfilter_conntrack libseccomp libselinux-utils"
 
 RUN yum install -q -y ${BUILD_TOOLS} \
     && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
-    && yum makecache
+    && yum makecache \
+    && yum install -y ${PKGS_IN_ISO}
 
 WORKDIR /centos/$OS_VERSION/os
 COPY build/os-packages/packages.yml .


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Reduce centos7 package size, After Reduced there are 130M in x86. 

And only the package not in the ISO would in the os-pkg.

```
du -sh /centos/7/os/x86_64/*
 ---> Running in 16eabea56baa
188K    /centos/7/os/x86_64/conntrack-tools-1.4.4-7.el7.x86_64.rpm
40K     /centos/7/os/x86_64/container-selinux-2.119.2-1.911c772.el7_8.noarch.rpm
34M     /centos/7/os/x86_64/containerd.io-1.6.18-3.1.el7.x86_64.rpm
13M     /centos/7/os/x86_64/docker-buildx-plugin-0.10.2-1.el7.x86_64.rpm
25M     /centos/7/os/x86_64/docker-ce-19.03.15-3.el7.x86_64.rpm
22M     /centos/7/os/x86_64/docker-ce-20.10.23-3.el7.x86_64.rpm
14M     /centos/7/os/x86_64/docker-ce-cli-23.0.1-1.el7.x86_64.rpm
8.9M    /centos/7/os/x86_64/docker-ce-rootless-extras-23.0.1-1.el7.x86_64.rpm
11M     /centos/7/os/x86_64/docker-compose-plugin-2.16.0-1.el7.x86_64.rpm
3.9M    /centos/7/os/x86_64/docker-scan-plugin-0.23.0-3.el7.x86_64.rpm
56K     /centos/7/os/x86_64/fuse-overlayfs-0.7.2-6.el7_8.x86_64.rpm
84K     /centos/7/os/x86_64/fuse3-libs-3.6.1-4.el7.x86_64.rpm
20K     /centos/7/os/x86_64/libnetfilter_cthelper-1.0.0-11.el7.x86_64.rpm
20K     /centos/7/os/x86_64/libnetfilter_cttimeout-1.0.0-7.el7.x86_64.rpm
24K     /centos/7/os/x86_64/libnetfilter_queue-1.0.2-2.el7_2.x86_64.rpm
56K     /centos/7/os/x86_64/repodata
84K     /centos/7/os/x86_64/slirp4netns-0.4.3-4.el7_8.x86_64.rpm
```

If it works , other OS can use the same method

**Which issue(s) this PR fixes**:

Fixes  https://github.com/kubean-io/kubean/issues/541

**Special notes for your reviewer**:

