### PR TITLE
Fix image name when push, and update the default k8s version to 1.26.0, fix kube_version of offline e2e 

### DIFF
--- a/.github/workflows/auto-kubean-compatibility-schedule.yaml
+++ b/.github/workflows/auto-kubean-compatibility-schedule.yaml
@@ -49,7 +49,7 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          VERSION=$(git describe --tags --abbrev=8 --dirty)
+          VERSION="$(git describe --tags --abbrev=8 --dirty)-e2e"
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $KUKEAN_OPERATOR_IMAGE_NAME $IMAGE_ID:$VERSION
@@ -63,7 +63,7 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          VERSION=$(git describe --tags --abbrev=8 --dirty)
+          VERSION="$(git describe --tags --abbrev=8 --dirty)-e2e"
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $SPRAY_JOB_IMAGE_NAME $IMAGE_ID:$VERSION

--- a/.github/workflows/auto-kubean-compatibility-schedule.yaml
+++ b/.github/workflows/auto-kubean-compatibility-schedule.yaml
@@ -69,7 +69,6 @@ jobs:
           docker tag $SPRAY_JOB_IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
   auto-kubean-compatibility:
-    needs: build-push-for-e2e
     runs-on: [self-hosted, online]
     permissions:
       packages: write

--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -113,7 +113,7 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          VERSION=$(git describe --tags --abbrev=8 --dirty)
+          VERSION="$(git describe --tags --abbrev=8 --dirty)-e2e"
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $KUKEAN_OPERATOR_IMAGE_NAME $IMAGE_ID:$VERSION
@@ -128,7 +128,7 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          VERSION=$(git describe --tags --abbrev=8 --dirty)
+          VERSION="$(git describe --tags --abbrev=8 --dirty)-e2e"
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $SPRAY_JOB_IMAGE_NAME $IMAGE_ID:$VERSION

--- a/.github/workflows/os_e2e_schedule.yaml
+++ b/.github/workflows/os_e2e_schedule.yaml
@@ -51,7 +51,7 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          VERSION=$(git describe --tags --abbrev=8 --dirty)
+          VERSION="$(git describe --tags --abbrev=8 --dirty)-e2e"
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $KUKEAN_OPERATOR_IMAGE_NAME $IMAGE_ID:$VERSION
@@ -65,7 +65,7 @@ jobs:
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
-          VERSION=$(git describe --tags --abbrev=8 --dirty)
+          VERSION="$(git describe --tags --abbrev=8 --dirty)-e2e"
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $SPRAY_JOB_IMAGE_NAME $IMAGE_ID:$VERSION

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -60,7 +60,7 @@ DIFF_COMPATIBILE=`git show | grep /test/kubean_os_compatibility_e2e || true`
 
 ####### e2e logic ########
 if [ "${E2E_TYPE}" == "KUBEAN-COMPATIBILITY" ]; then
-    k8s_list=( "v1.20.15" "v1.21.14" "v1.22.15" "v1.23.13" "v1.24.7" "v1.25.3" )
+    k8s_list=( "v1.20.15" "v1.21.14" "v1.22.15" "v1.23.13" "v1.24.7" "v1.25.3" "v1.26.0" )
     echo ${#k8s_list[@]}
     for k8s in "${k8s_list[@]}"; do
         echo "***************k8s version is: ${k8s} ***************"
@@ -72,7 +72,7 @@ if [ "${E2E_TYPE}" == "KUBEAN-COMPATIBILITY" ]; then
 
 else
     util::clean_online_kind_cluster
-    KIND_VERSION="release-ci.daocloud.io/kpanda/kindest-node:v1.25.3"
+    KIND_VERSION="release-ci.daocloud.io/kpanda/kindest-node:v1.26.0"
     ./hack/local-up-kindcluster.sh "${TARGET_VERSION}" "${IMAGE_VERSION}" "${HELM_REPO}" "${IMG_REPO}" "${KIND_VERSION}" "${CLUSTER_PREFIX}"-host
 
     if [ "${E2E_TYPE}" == "PR" ]; then

--- a/hack/offline-e2e.sh
+++ b/hack/offline-e2e.sh
@@ -46,7 +46,7 @@ source "${REPO_ROOT}"/hack/util.sh
 source "${REPO_ROOT}"/hack/offline-util.sh
 
 if [[ ${HELM_CHART_VERSION} =~ .*rc ]];then
-  echo "RC version, remain the the kube_version to 1.24.7"
+  echo "RC version, remain the the kube_version to 1.25.4"
 #else
    #sed -i '/kube_version: /d' ${REPO_ROOT}/test/offline-common/vars-conf-cm.yml
 fi

--- a/test/offline-common/vars-conf-cm.yml
+++ b/test/offline-common/vars-conf-cm.yml
@@ -38,7 +38,7 @@ data:
     # github image repo define (ex multus only use that)
     github_image_repo: "{{registry_host}}/ghcr.io"
     # k8s-cluster
-    kube_version: "v1.24.7"
+    kube_version: "v1.25.4"
     container_manager: containerd
     k8s_image_pull_policy: IfNotPresent
     kube_network_plugin: calico


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug
**What this PR does / why we need it**:
rename the image build and push for compatibility and pr ci.
update the default k8s version to 1.26.0.
  
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #565

**Special notes for your reviewer**:
https://github.com/XiuguangHuang/kubean/actions/runs/4396531877/jobs/7699032652
![image](https://user-images.githubusercontent.com/96054687/224622499-74d7f82f-6e68-42ff-9a90-2003fa117c19.png)

![image](https://user-images.githubusercontent.com/96054687/224622565-993989c3-d06f-4b70-ad45-cc7d65990016.png)
