### PR TITLE
add unsafe_show_logs to debug the download failed resource

### DIFF
--- a/test/common/vars-conf-cm.yml
+++ b/test/common/vars-conf-cm.yml
@@ -6,6 +6,7 @@ metadata:
 data:
   group_vars.yml: |
     # k8s-cluster
+    unsafe_show_logs: true
     kube_version: "v1.24.7"
     container_manager: containerd
     k8s_image_pull_policy: IfNotPresent


### PR DESCRIPTION
unsafe_show_logs: true is added in online e2e config

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

