### PR TITLE
Fix KUBEAN_E2E_TEST_CI Error: A branch or tag with the name kubean_ci_test could not be found

### DIFF
--- a/.github/workflows/kubean_e2e_test_ci.yaml
+++ b/.github/workflows/kubean_e2e_test_ci.yaml
@@ -112,7 +112,6 @@ jobs:
           echo "JOB_NAME=${JOB_NAME,,}" >> ${GITHUB_ENV}
       - uses: actions/checkout@v3
         with:
-          ref: kubean_ci_test
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
@@ -124,7 +123,7 @@ jobs:
 
   centos_calico_online:
     runs-on: ubuntu-latest
-    needs: [centos_calico_airgap, get_helm_version, build-push-for-e2e]
+    needs: [centos_calico_airgap, get_helm_version]
     env:
       CONTAINER_TAG: ${{ needs.get_helm_version.outputs.CONTAINER_TAG }}
       HELM_CHART_VERSION: ${{ needs.get_helm_version.outputs.HELM_CHART_VERSION }}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
CI fail:
https://github.com/kubean-io/kubean/actions/runs/4925077385/jobs/8798879826

