### PR TITLE
fix error: Failed to compile kubean_ipvs_cluster_e2e

### DIFF
--- a/.github/workflows/kubean_e2e_test_ci.yaml
+++ b/.github/workflows/kubean_e2e_test_ci.yaml
@@ -147,6 +147,7 @@ jobs:
           bash ./hack/newE2E.sh
 
   centos_cilium_online:
+    # This is actually e2e_offline action
     runs-on:  [self-hosted, offline]
     needs: [centos_calico_airgap, get_helm_version]
     env:
@@ -168,9 +169,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.4
+      # - uses: actions/setup-go@v3
+      #   with:
+      #     go-version: 1.20.4
       - name: centos_cilium_online
         continue-on-error: ${{ vars.CENTOS_CILIUM_ONLINE_ALLOW_FAILURE != 'false' }}
         run: |


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**Which issue(s) this PR fixes**:

In KUBEAN_E2E_TEST_CI action, e2e offlline workflow failed cause go version is not correct:
https://github.com/kubean-io/kubean/actions/runs/5088221843/jobs/9144388983

![image](https://github.com/kubean-io/kubean/assets/13757056/917227fe-1ef1-4ad0-959d-82139bd5cfd7)
