### PR TITLE
[e2e test] change kindest version to v1.26.4

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -75,7 +75,7 @@ if [ "${E2E_TYPE}" == "KUBEAN-COMPATIBILITY" ]; then
 
 else
     util::clean_online_kind_cluster
-    KIND_VERSION="release-ci.daocloud.io/kpanda/kindest-node:v1.26.0"
+    KIND_VERSION="release-ci.daocloud.io/kpanda/kindest-node:v1.26.4"
     ./hack/local-up-kindcluster.sh "${TARGET_VERSION}" "${IMAGE_VERSION}" "${HELM_REPO}" "${IMG_REGISTRY}" "${KIND_VERSION}" "${CLUSTER_PREFIX}"-host
     util::set_config_path
     if [ "${E2E_TYPE}" == "PR" ]; then

--- a/hack/local-up-kindcluster.sh
+++ b/hack/local-up-kindcluster.sh
@@ -42,7 +42,7 @@ util::verify_go_version
 util::cmd_must_exist "helm"
 
 # install kind and kubectl
-kind_version=v0.17.0
+kind_version=v0.19.0
 util::install_kind $kind_version
 
 # get arch name and os name in bootstrap

--- a/hack/offline-e2e.sh
+++ b/hack/offline-e2e.sh
@@ -53,7 +53,7 @@ source "${REPO_ROOT}"/hack/util.sh
 source "${REPO_ROOT}"/hack/offline-util.sh
 
 if [[ ${HELM_CHART_VERSION} =~ .*rc ]];then
-  echo "RC version, remain the the kube_version to 1.25.4"
+  echo "RC version, remain the the kube_version to 1.26.5"
 #else
    #sed -i '/kube_version: /d' ${REPO_ROOT}/test/offline-common/vars-conf-cm.yml
 fi
@@ -70,7 +70,7 @@ helm repo add ${local_helm_repo_alias} ${HELM_REPO}
 helm repo update
 helm repo list
 
-KIND_VERSION="release-ci.daocloud.io/kpanda/kindest-node:v1.25.3"
+KIND_VERSION="release-ci.daocloud.io/kpanda/kindest-node:v1.26.4"
 ./hack/local-up-kindcluster.sh "${HELM_CHART_VERSION}" "${IMAGE_VERSION}" "${HELM_REPO}" "${IMG_REGISTRY}" "${KIND_VERSION}" "${CLUSTER_PREFIX}"-host
 ### Helm install Registry: AMD64 registry and ARM64 registry
 util::install_registry "${REGISTRY_PORT_AMD64}" "${KUBECONFIG_FILE}" "registry-amd64"


### PR DESCRIPTION
[e2e test] change kindest version to v1.26.4
**What type of PR is this?**
/kind-cleanup
**What this PR does / why we need it:**
for update kindest node version
**Which issue(s) this PR fixes:**
change log:
1 e2e.sh KIND_VERSION change to  v1.26.4
2 offline-e2e.sh KIND_VERSION change to  v1.26.4
3 util::install_kind $kind_version=v0.19.0
https://github.com/kubernetes-sigs/kind/releases

![image](https://github.com/kubean-io/kubean/assets/31728060/f6b932ba-5d18-4568-9d7f-277e16766a0c)

**Special notes for your reviewer:**
checked:
e2e-schedule pass
auto-offline install kubean success in kind cluster
![企业微信截图_af8768a9-113d-4281-8dc9-3dc0ebf49748](https://github.com/kubean-io/kubean/assets/31728060/11352ce3-56d7-4012-bde9-509c8e661bb1)

