### PR TITLE
[test] release CI auto to update the 'k8s supported version range list'

### DIFF
--- a/hack/autoversion.sh
+++ b/hack/autoversion.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBEAN_VERSION=${1:-"v0.6.5"}
+
+# Now the runner's OS is is Centos7
+if ! which yq; then
+    echo "need yq (https://github.com/mikefarah/yq)."
+    wget https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_amd64
+    chmod 777 yq_linux_amd64
+    mv yq_linux_amd64 /usr/bin/yq 
+fi
+
+# get default k8s version from /charts/kubean/templates/manifest.cr.yaml
+function get_default_k8s_version() {
+  rm manifest.cr.yaml -rf
+  curl https://raw.githubusercontent.com/kubean-io/kubean-helm-chart/kubean-${KUBEAN_VERSION}/charts/kubean/templates/manifest.cr.yaml -O
+  range=$(cat manifest.cr.yaml| yq '.spec.components[] | select(.name=="kube")' | yq '.defaultVersion' | tr '"' "'")
+  echo ${range//- / }
+}
+
+# get k8s version range from /charts/kubean/templates/manifest.cr.yaml
+function get_k8s_version_range() {
+  rm manifest.cr.yaml -rf
+  curl https://raw.githubusercontent.com/kubean-io/kubean-helm-chart/kubean-${KUBEAN_VERSION}/charts/kubean/templates/manifest.cr.yaml -O
+  # get versionRange string 
+  range=$(cat manifest.cr.yaml| yq '.spec.components[] | select(.name=="kube")' | yq '.versionRange' | tr '"' "'")
+  # replace each - with <br\/>       -, divide into one line, remove \n and remove the first <br\/>        
+  echo "$range" | sed 's/-/<br\/>       -/g'|sed ':a;N;$!ba;s/\n/ /g'| sed 's/<br\/>       //'
+}
+
+ k8s_version_range=$(get_k8s_version_range)
+ echo "${k8s_version_range}"
+ default_k8s_version=$(get_default_k8s_version)
+ echo "default_k8s_version: ${default_k8s_version}"
+
+# print tab content
+function k8s_version_tab_render() { 
+  #printf -- "| %-13s | %-24s | %s |\n" 'kubean Version' 'Default Kubernetes Version' 'Supported Kubernetes Version Range'
+  #printf -- "| %-13s| %-24s| %s|\n" '-----------' '----------------------' '------------------------------------------------------------'
+  printf -- "| %-13s | %-24s| %s|\n" "$KUBEAN_VERSION" "$default_k8s_version" "$k8s_version_range"
+}
+support_file_path="./docs/zh/usage/support-k8s-version.md"
+k8s_version_tab_render >> "$support_file_path"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -59,6 +59,7 @@ chmod +x ./hack/run-network-e2e.sh
 chmod +x ./hack/run-nightly-cluster-e2e.sh
 chmod +x ./hack/kubean_compatibility_e2e.sh
 chmod +x ./hack/kubean_resource.sh
+chmod +x ./hack/autoversion.sh
 DIFF_NIGHTLYE2E=`git show -- './test/*' | grep nightlye2e || true`
 DIFF_COMPATIBILE=`git show | grep /test/kubean_os_compatibility_e2e || true`
 
@@ -70,6 +71,7 @@ if [ "${E2E_TYPE}" == "KUBEAN-COMPATIBILITY" ]; then
         echo "***************k8s version is: ${k8s} ***************"
         kind::clean_kind_cluster ${CONTAINERS_PREFIX}
         KIND_VERSION="release-ci.daocloud.io/kpanda/kindest-node:"${k8s}
+        ./hack/autoversion.sh "${IMAGE_VERSION}"
         ./hack/local-up-kindcluster.sh "${TARGET_VERSION}" "${IMAGE_VERSION}" "${HELM_REPO}" "${IMG_REGISTRY}" "${KIND_VERSION}" "${CLUSTER_PREFIX}"-host
         ./hack/kubean_compatibility_e2e.sh
     done


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
get from charts/kubean/templates/manifest.cr.yaml
auto write into docs/zh/usage/support-k8s-version.md

**Special notes for your reviewer**:
Local pass 
![image](https://github.com/kubean-io/kubean/assets/31728060/a29a09f0-072d-48db-b3e9-62c28ac8522a)

effect:
![image](https://github.com/kubean-io/kubean/assets/31728060/aa7e6ab5-bce2-41b7-98f0-f912ac4ed913)

