### PR TITLE
Fix incorrect ansible pkgmgr detection for tencentos

### DIFF
--- a/build/images/patch_files/pkg_mgr.py
+++ b/build/images/patch_files/pkg_mgr.py
@@ -107,6 +107,11 @@ class PkgMgrFactCollector(BaseFactCollector):
                         pkg_mgr_name = 'dnf'
             except ValueError:
                 pkg_mgr_name = 'dnf'
+        elif collected_facts['ansible_distribution'] == 'TencentOS':
+            try:
+                pkg_mgr_name = 'dnf' if int(collected_facts['ansible_distribution_major_version']) >= 3 else 'yum'
+            except ValueError:
+                pkg_mgr_name = 'dnf'
         else:
             # If it's not one of the above and it's Red Hat family of distros, assume
             # RHEL or a clone. For versions of RHEL < 8 that Ansible supports, the


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

**What type of PR is this?**
<!-- 
Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind api-change
/kind bug
/kind cleanup
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
-->
/kind bug

**What this PR does / why we need it**:
Fix incorrect ansible pkgmgr detection for tencentos

![image](https://github.com/kubean-io/kubean/assets/92532497/f869e6af-b6b3-4fb5-95c2-96b960a65f9d)

The default behavior is like this:
![image](https://github.com/kubean-io/kubean/assets/92532497/a146acec-fe19-4318-b883-7ea9879bf82f)
After fixed:
![image](https://github.com/kubean-io/kubean/assets/92532497/4223dfd3-1c5e-4a55-9491-e39a00696f5f)


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

