### PR TITLE
Revert "Bump Kubespray version"

### DIFF
--- a/version.yml
+++ b/version.yml
@@ -1,2 +1,2 @@
-kubespray_version: 5ed85094c2cb55784edae1725aff64684fd6351a
+kubespray_version: 36e5d742dc2b3f7984398c38009f236be7c3c065
 kubernetes_version: v1.26.7


### PR DESCRIPTION
Reverts kubean-io/kubean#937

Upstream introduce a breaking change https://github.com/kubernetes-sigs/kubespray/commit/77bda0df1c3b66b5e2f4e47319277ece66bcae8d. Now revert temporarily