### PR TITLE
fix upload assets greater than 2 GiB issue

### DIFF
--- a/.github/workflows/call-build-imgs-for-spray.yaml
+++ b/.github/workflows/call-build-imgs-for-spray.yaml
@@ -46,13 +46,12 @@ jobs:
     - name: Checks if a image with the same tag exists
       id: check
       run: |
+        echo "need_rebuild=true" >>$GITHUB_OUTPUT
         commit_short_sha=${{ needs.output-variable.outputs.image_tag_short_sha }}
-        ghcr_token=$(curl https://ghcr.io/token\?scope\="repository:kubean-io/kubespray:pull" | jq '.token' | tr -d '"')
-        curl -H "Authorization: Bearer ${ghcr_token}" https://ghcr.io/v2/kubean-io/kubespray/tags/list | jq '.tags' | tr -d '[",]' > tags
+        ghcr_token=$(curl https://ghcr.io/token\?scope\="repository:${{ inputs.REPO }}/kubespray:pull" | jq '.token' | tr -d '"')
+        curl -H "Authorization: Bearer ${ghcr_token}" https://ghcr.io/v2/${{ inputs.REPO }}/kubespray/tags/list | jq '.tags' | tr -d '[",]' > tags
         if grep -q ${commit_short_sha} tags; then
           echo "need_rebuild=false" >>$GITHUB_OUTPUT
-        else
-          echo "need_rebuild=true" >>$GITHUB_OUTPUT
         fi
 
     - uses: actions/checkout@v3

--- a/.github/workflows/call-offline-build.yaml
+++ b/.github/workflows/call-offline-build.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set kubespray version env
       run: |
         echo "SPRAY_VERSION=$(yq ".kubespray_version" version.yml)" >> ${GITHUB_ENV}
-        echo "KUBE_VERSION=$(yq ".kubernetes_version" version.yml)" >> ${GITHUB_ENV} 
+        echo "KUBE_VERSION=$(yq ".kubernetes_version" version.yml)" >> ${GITHUB_ENV}
 
     - name: Git clone kubespray repo
       uses: actions/checkout@v3
@@ -84,6 +84,9 @@ jobs:
         mv images.list images-${ARCH}.list
         cd ../../
         tree ${KUBEAN_TAG}/
+        echo -e "\noutput files size:\n"
+        ls -lh ${KUBEAN_TAG}/amd64/
+        ls -lh ${KUBEAN_TAG}/arm64/
 
     - name: Release and upload packages
       if: startsWith(github.ref, 'refs/tags/')

--- a/artifacts/generate_offline_package.sh
+++ b/artifacts/generate_offline_package.sh
@@ -140,10 +140,7 @@ function create_images() {
   local images_list_content
   images_list_content=$(cat "${CURRENT_DIR}/kubespray/contrib/offline/temp/images.list")
 
-  if [ ! -d "offline-images" ]; then
-    echo "create offline-images directory."
-    mkdir offline-images
-  fi
+  rm -rf offline-images && mkdir offline-images
 
   while read -r image_name; do
     echo "download image $image_name to local"


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Because in the scenario of exporting multi-architecture images, the OCI directory is incorrectly reused, causing the final tar package size to exceed 2G.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

https://github.com/ErikJiang/kubean/actions/runs/6899326250/job/18770745798