### PR TITLE
Revert "Bump actions/setup-go from 4 to 5"

### DIFF
--- a/.github/workflows/auto-kubean-compatibility-schedule.yaml
+++ b/.github/workflows/auto-kubean-compatibility-schedule.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
 

--- a/.github/workflows/auto-main-ci.yaml
+++ b/.github/workflows/auto-main-ci.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v4
       with:
         go-version: 1.20.4
 

--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.get_ref.outputs.ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
 
@@ -74,7 +74,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.get_ref.outputs.ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
 
@@ -181,7 +181,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.get_ref.outputs.ref }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: e2e

--- a/.github/workflows/e2e_schedule.yaml
+++ b/.github/workflows/e2e_schedule.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
 

--- a/.github/workflows/kubean_e2e_test_ci.yaml
+++ b/.github/workflows/kubean_e2e_test_ci.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: centos_calico_airgap
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: centos_calico_online
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      # - uses: actions/setup-go@v5
+      # - uses: actions/setup-go@v4
       #   with:
       #     go-version: 1.20.4
       - name: centos_cilium_online
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: centos_cilium_airgap
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: redhat_calico_online
@@ -230,7 +230,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: redhat_calico_airgap
@@ -261,7 +261,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: redhat_cilium_airgap
@@ -293,7 +293,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: redhat_cilium_online
@@ -325,7 +325,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: kylin_calico_online
@@ -357,7 +357,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: kylin_calico_airgap

--- a/.github/workflows/os_e2e_schedule.yaml
+++ b/.github/workflows/os_e2e_schedule.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
 

--- a/.github/workflows/verify-kubespray.yaml
+++ b/.github/workflows/verify-kubespray.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.get_ref.outputs.ref }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - name: verify_kubespray_e2e_test


### PR DESCRIPTION
Reverts kubean-io/kubean#1047

![image](https://github.com/kubean-io/kubean/assets/10629406/e4e65b21-99ba-4593-adc7-5a282d90e0bc)
https://github.com/kubean-io/kubean/actions/runs/7189703995/job/19582212290