### PR TITLE
set default flag for airgap full mode

### DIFF
--- a/artifacts/airgap_patch.py
+++ b/artifacts/airgap_patch.py
@@ -118,6 +118,8 @@ def create_localartifactset_cr(manifest_data):
             component_name = re.split('_', version_key)[0]
             if item_name == component_name:
                 versions = manifest_data.get(version_key)
+                if MODE == "FULL" and component_name != 'kube' and versions is None:
+                    versions = ['default']
                 if isinstance(versions, list):
                     item["versionRange"] = versions
                 if isinstance(versions, str):


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind enhancement

#### What this PR does / why we need it:
Full mode identifies the default version of the component.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
![image](https://github.com/kubean-io/kubean/assets/10629406/458aed00-3e4a-4077-9e49-4bed85687601)
