### PR TITLE
Fix coredns image version mismatch

### DIFF
--- a/artifacts/airgap_patch.py
+++ b/artifacts/airgap_patch.py
@@ -29,7 +29,7 @@ OFFLINE_VER_CR_TEMP = os.getenv("OFFLINEVERSION_CR_TEMPLATE",
                                 default=os.path.join(CUR_DIR,
                                                      "artifacts/template/localartifactset.template.yml"))
 KEYWORDS = {
-    "kube_version": ["/kubelet", "/kubectl", "/kubeadm", "/kube-apiserver", "/kube-controller-manager", "/kube-scheduler", "/kube-proxy", "/pause"],
+    "kube_version": ["kubelet", "kubectl", "kubeadm", "kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy", "pause", "coredns"],
     "cni_version": ["cni"],
     "containerd_version": ['containerd'],
     "calico_version": ['calico'],
@@ -146,7 +146,7 @@ def get_manifest_data():
 def get_other_required_keywords(manifest_dict):
     other_required_keywords = [
         "crictl", "cri-o", "runc", "crun", "runsc", "cri-dockerd", "yq",
-        "coredns", "nginx", "k8s-dns-node-cache", "cluster-proportional-autoscaler"]
+        "nginx", "k8s-dns-node-cache", "cluster-proportional-autoscaler"]
     manifest_keys = [ key for key in manifest_dict]
     keys_range = [ key for key in KEYWORDS]
     list_diff = list(set(keys_range) - set(manifest_keys))


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind enhancement
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind design
/kind regression
-->

#### What this PR does / why we need it:
The coredns image generated by the airgap_patch image does not match the actual installed version.
``` json
{
  "attempts": 1,
  "changed": true,
  "cmd":
    [
      "/usr/local/bin/nerdctl",
      "-n",
      "k8s.io",
      "pull",
      "--quiet",
      "--insecure-registry",
      "172.30.41.161:30080/registry.k8s.io/coredns/coredns:v1.9.3",
    ],
  "delta": "0:00:00.047678",
  "end": "2024-01-10 22:34:41.775262",
  "msg": "non-zero return code",
  "rc": 1,
  "start": "2024-01-10 22:34:41.727584",
  "stderr": "time=\"2024-01-10T22:34:41-05:00\" level=warning msg=\"skipping verifying HTTPS certs for \\\"172.30.41.161:30080\\\"\"\ntime=\"2024-01-10T22:34:41-05:00\" level=info msg=\"trying next host\" error=\"failed to do request: Head \\\"https://172.30.41.161:30080/v2/registry.k8s.io/coredns/coredns/manifests/v1.9.3\\\": http: server gave HTTP response to HTTPS client\" host=\"172.30.41.161:30080\"\ntime=\"2024-01-10T22:34:41-05:00\" level=warning msg=\"server \\\"172.30.41.161:30080\\\" does not seem to support HTTPS, falling back to plain HTTP\" error=\"failed to resolve reference \\\"172.30.41.161:30080/registry.k8s.io/coredns/coredns:v1.9.3\\\": failed to do request: Head \\\"https://172.30.41.161:30080/v2/registry.k8s.io/coredns/coredns/manifests/v1.9.3\\\": http: server gave HTTP response to HTTPS client\"\ntime=\"2024-01-10T22:34:41-05:00\" level=info msg=\"trying next host - response was http.StatusNotFound\" host=\"172.30.41.161:30080\"\ntime=\"2024-01-10T22:34:41-05:00\" level=fatal msg=\"failed to resolve reference \\\"172.30.41.161:30080/registry.k8s.io/coredns/coredns:v1.9.3\\\": 172.30.41.161:30080/registry.k8s.io/coredns/coredns:v1.9.3: not found\"",
  "stderr_lines":
    [
      "time=\"2024-01-10T22:34:41-05:00\" level=warning msg=\"skipping verifying HTTPS certs for \\\"172.30.41.161:30080\\\"\"",
      "time=\"2024-01-10T22:34:41-05:00\" level=info msg=\"trying next host\" error=\"failed to do request: Head \\\"https://172.30.41.161:30080/v2/registry.k8s.io/coredns/coredns/manifests/v1.9.3\\\": http: server gave HTTP response to HTTPS client\" host=\"172.30.41.161:30080\"",
      "time=\"2024-01-10T22:34:41-05:00\" level=warning msg=\"server \\\"172.30.41.161:30080\\\" does not seem to support HTTPS, falling back to plain HTTP\" error=\"failed to resolve reference \\\"172.30.41.161:30080/registry.k8s.io/coredns/coredns:v1.9.3\\\": failed to do request: Head \\\"https://172.30.41.161:30080/v2/registry.k8s.io/coredns/coredns/manifests/v1.9.3\\\": http: server gave HTTP response to HTTPS client\"",
      'time="2024-01-10T22:34:41-05:00" level=info msg="trying next host - response was http.StatusNotFound" host="172.30.41.161:30080"',
      "time=\"2024-01-10T22:34:41-05:00\" level=fatal msg=\"failed to resolve reference \\\"172.30.41.161:30080/registry.k8s.io/coredns/coredns:v1.9.3\\\": 172.30.41.161:30080/registry.k8s.io/coredns/coredns:v1.9.3: not found\"",
    ],
  "stdout": "",
  "stdout_lines": [],
}
```
![image](https://github.com/kubean-io/kubean/assets/10629406/84651aa5-fcc1-47f5-8edb-b19d76b8bbe3)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
