### PR TITLE
fixed crictl binary version mismatch

### DIFF
--- a/artifacts/airgap_patch.py
+++ b/artifacts/airgap_patch.py
@@ -29,7 +29,8 @@ OFFLINE_VER_CR_TEMP = os.getenv("OFFLINEVERSION_CR_TEMPLATE",
                                 default=os.path.join(CUR_DIR,
                                                      "artifacts/template/localartifactset.template.yml"))
 KEYWORDS = {
-    "kube_version": ["kubelet", "kubectl", "kubeadm", "kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy", "pause", "coredns"],
+    "kube_version": ["kubelet", "kubectl", "kubeadm", "kube-apiserver", "kube-controller-manager", "kube-scheduler", "kube-proxy",
+                     "pause", "coredns", "crictl", "cri-o"],
     "cni_version": ["cni"],
     "containerd_version": ['containerd'],
     "calico_version": ['calico'],
@@ -145,8 +146,7 @@ def get_manifest_data():
 
 def get_other_required_keywords(manifest_dict):
     other_required_keywords = [
-        "crictl", "cri-o", "runc", "crun", "runsc", "cri-dockerd", "yq",
-        "nginx", "k8s-dns-node-cache", "cluster-proportional-autoscaler"]
+        "runc", "crun", "runsc", "cri-dockerd", "yq", "nginx", "k8s-dns-node-cache", "cluster-proportional-autoscaler"]
     manifest_keys = [ key for key in manifest_dict]
     keys_range = [ key for key in KEYWORDS]
     list_diff = list(set(keys_range) - set(manifest_keys))


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
crictl is associated with the kube version and should be dynamically retrieved from its download url.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
