### PR TITLE
Remove kubectl get version option

### DIFF
--- a/test/kubean_sonobouy_nightlye2e/kubean_cluster_sonobouy_test.go
+++ b/test/kubean_sonobouy_nightlye2e/kubean_cluster_sonobouy_test.go
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 			tools.WaitPodSInKubeSystemBeRunning(cluster1Client, 1800)
 
 			// kubectl version should be：tools.UpgradeK8Version_Y
-			kubectlCmd := tools.RemoteSSHCmdArrayByPasswd(password, []string{masterSSH, "kubectl", "version", "--short"})
+			kubectlCmd := tools.RemoteSSHCmdArrayByPasswd(password, []string{masterSSH, "kubectl", "version"})
 			kubectlOut, _ := tools.NewDoCmd("sshpass", kubectlCmd...)
 			klog.Info(kubectlOut.String())
 			gomega.Expect(kubectlOut.String()).Should(gomega.ContainSubstring(tools.UpgradeK8Version_Y))


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind e2e
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind enhancement
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind design
/kind regression
-->

#### What this PR does / why we need it:
In 1.28.0, --short option is removed for kubectl version

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubean-io/kubean/actions/runs/7800940964/job/21297482870

#### Special notes for your reviewer:
