### PR TITLE
Add playbook to enable nf_conntrack

### DIFF
--- a/pkg/util/entrypoint/entrypoint.go
+++ b/pkg/util/entrypoint/entrypoint.go
@@ -35,6 +35,7 @@ const (
 	RenewCertsPB             = "renew-certs.yml"
 	KubeVipConfigPB          = "config-for-kube-vip.yml"
 	ConfigInsecureRegistryPB = "config-insecure-registry.yml"
+	NfConntrackPB            = "enable-nf-conntrack.yml"
 )
 
 //go:embed entrypoint.sh.template
@@ -61,7 +62,7 @@ func NewActions() *Actions {
 	actions.Playbooks.List = []string{
 		ResetPB, ScalePB, ClusterPB, RemoveNodePB, UpgradeClusterPB,
 		PingPB, RepoPB, FirewallPB, KubeconfigPB, ClusterInfoPB, UpdateHostsPB,
-		RemovePkgsPB, PreCheckPB, RenewCertsPB, KubeVipConfigPB, ConfigInsecureRegistryPB,
+		RemovePkgsPB, PreCheckPB, RenewCertsPB, KubeVipConfigPB, ConfigInsecureRegistryPB, NfConntrackPB,
 	}
 	actions.Playbooks.Dict = map[string]void{}
 	for _, pbItem := range actions.Playbooks.List {

--- a/playbooks/enable-nf-conntrack.yml
+++ b/playbooks/enable-nf-conntrack.yml
@@ -1,0 +1,35 @@
+# Copyright 2023 Authors of kubean-io
+# SPDX-License-Identifier: Apache-2.0
+
+---
+- name: Enable nf_conntrack kernel module
+  hosts: all
+  become: true
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  tasks:
+    - name: Check OS and enable nf_conntrack
+      command: lsmod | grep nf_conntrack
+      register: nf_conntrack_check
+      ignore_errors: true
+
+    - name: Enable nf_conntrack for non-RedHat8/Rocky OS
+      command: modprobe nf_conntrack
+      when:
+        - ansible_distribution != "Rocky" or (ansible_distribution == "RedHat" and ansible_distribution_major_version != "8")
+        - nf_conntrack_check.rc != 0
+
+    - name: Persist nf_conntrack configuration
+      when:
+        - ansible_distribution != "Rocky" or (ansible_distribution == "RedHat" and ansible_distribution_major_version != "8")
+        - nf_conntrack_check.rc != 0
+      block:
+        - name: Ensure nf_conntrack configuration file exists
+          file:
+            path: /etc/modules-load.d/nf_conntrack.conf
+            state: touch
+            mode: "0644"
+        - name: Add nf_conntrack to configuration file
+          lineinfile:
+            path: /etc/modules-load.d/nf_conntrack.conf
+            line: "nf_conntrack"
+            state: present


### PR DESCRIPTION
Add playbook to config insecure registry

<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
To enable node sysctl tuning, we need make sure nf_conntrack is enabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Rocky and redhat8 os doesnot have this problem.