### PR TITLE
fix missing lib file in arm-arch container

### DIFF
--- a/artifacts/gen_airgap_pkgs.sh
+++ b/artifacts/gen_airgap_pkgs.sh
@@ -24,42 +24,6 @@ function generate_offline_dir() {
   mkdir -p $OFFLINE_OSPKGS_DIR
 }
 
-function bump_pause_version() {
-  major_version=$(echo "$1" | awk -F . '{print int($1)}')
-  minor_version=$(echo "$1" | awk -F . '{print int($2)}')
-  patch_version=$(echo "$1" | awk -F . '{print int($3)}')
-
-  local bump_versions=()
-  bump_versions+=("${major_version}.$((minor_version + 1))")
-  bump_versions+=("${major_version}.$((minor_version + 1)).1")
-  bump_versions+=("${major_version}.${minor_version}.$((patch_version + 1))")
-  bump_versions+=("$((major_version + 1)).0")
-  local bump_pause_tag=""
-  for tag in "${bump_versions[@]}"; do
-    local ret=0
-    curl -sL https://registry.k8s.io/v2/pause/tags/list | jq .tags | grep -v sha256 | grep -q "\"${tag}\"" || ret=$?
-    if [[ "${ret}" == 0 ]]; then
-      bump_pause_tag=${tag}
-      break
-    fi
-  done
-  echo "${bump_pause_tag}"
-}
-
-function add_pause_image_addr() {
-  local image_list=$1
-  local pause_img_addr
-  pause_img_addr=$(< "${image_list}" grep pause)
-  if [ -n "${pause_img_addr}" ]; then
-    pause_addr=$(echo "${pause_img_addr}" | cut -d: -f1)
-    pause_tag=$(echo "${pause_img_addr}" | cut -d: -f2)
-    new_tag=$(bump_pause_version "${pause_tag}")
-    if [ -n "${new_tag}" ]; then
-      echo "${pause_addr}:${new_tag}" >> "${image_list}"
-    fi
-  fi
-}
-
 function generate_temp_list() {
   if [ ! -d "kubespray" ]; then
     echo "kubespray git repo should exist."
@@ -78,7 +42,6 @@ function generate_temp_list() {
   remove_images="aws-alb|aws-ebs|cert-manager|netchecker|weave|sig-storage|external_storage|cinder-csi|kubernetesui"
   mv contrib/offline/temp/images.list contrib/offline/temp/images.list.old
   cat contrib/offline/temp/images.list.old | egrep -v ${remove_images} > contrib/offline/temp/images.list
-  add_pause_image_addr contrib/offline/temp/images.list
   cp contrib/offline/temp/*.list ${OFFLINE_PACKAGE_DIR}
 }
 

--- a/build/images/airgap-patch/Dockerfile
+++ b/build/images/airgap-patch/Dockerfile
@@ -20,7 +20,7 @@ COPY charts /kubean/charts
 ARG SKOPEO_VERSION="v1.11.2"
 ARG YQ_VERSION="v4.33.3"
 RUN ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" \
-    && apk add --update --no-cache curl wget \
+    && apk add --update --no-cache curl wget libc6-compat \
     && echo "install skopeo" \
     && wget -O /usr/bin/skopeo https://github.com/lework/skopeo-binary/releases/download/${SKOPEO_VERSION}/skopeo-linux-${ARCH} \
     && chmod +x /usr/bin/skopeo \


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The arm architecture airgap-patch container environment is missing the `/lib/ld-linux-aarch64.so.1` library file, causing the skopeo tool to fail to run properly. install `libc6-compat` can resolve this issue.
![skopeo cannot execute](https://github.com/kubean-io/kubean/assets/10629406/ee42ae63-aecf-4925-8099-14562d36ba00)

Additionally, unnecessary logic regarding the increment of tags for the pause image has been cleaned up.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
