### PR TITLE
fix build os-pkg for ubuntu2004: set containerd to 1.6.28-1 when install docker

### DIFF
--- a/build/os-packages/Dockerfile.ubuntu2004
+++ b/build/os-packages/Dockerfile.ubuntu2004
@@ -21,7 +21,7 @@ RUN yq eval '.common[],.apt[],.ubuntu2004[]' packages.yml > packages.list \
     && while read -r line; do \
         if [[ $line == docker-ce* ]]; then \
             version=$(echo $line | cut -d'=' -f2); \
-            line="$line docker-ce-cli=$version"; \
+            line="$line docker-ce-cli=$version containerd.io=1.6.28-1"; \
         fi; \
         apt-get install --reinstall --print-uris $line | egrep "https|http" | awk -F "'" '{print $2}' >> urls.list; \
        done <<<"$(sort -u packages.list)"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
when run `apt-get install --reinstall --print-uris docker-ce=xxx`, the dependency containerd.io=1.6.28-2 is installed, 
but kubespray needs containerd.io=1.6.28-1

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:
