### PR TITLE
Bump python version for offline build github action

### DIFF
--- a/.github/workflows/call-offline-build.yaml
+++ b/.github/workflows/call-offline-build.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Preparing the python environment
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: 3.11
 
     - name: Install kubespray requirements
       run: |


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind enhancement
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind design
/kind regression
-->

#### What this PR does / why we need it:

Fix pipeline https://github.com/kubean-io/kubean/actions/runs/8532924412/job/23374837615

Upstream has been updated ansible core version to [9.3.0](https://github.com/kubernetes-sigs/kubespray/blob/fdf5988ea8d3d1aea51dc3ea669b9337cba4988f/requirements.txt#L1). However, ansible [9.3.0](https://pypi.org/project/ansible/9.3.0/) requires a minimum python 3.10.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
