### PR TITLE
Modify Kubespray CI's rebuild logic for image building

### DIFF
--- a/.github/workflows/call-build-imgs-for-spray.yaml
+++ b/.github/workflows/call-build-imgs-for-spray.yaml
@@ -38,6 +38,7 @@ jobs:
           SPRAY_SHA=${INPUTS_SPRAY_REF}
         fi
         echo image_tag_short_sha=$(echo ${SPRAY_SHA} | cut -c 1-7) >> $GITHUB_OUTPUT
+        echo dockerfile_commit=$(git log -1 --pretty=format:"%H" build/images/kubespray/Dockerfile) >> $GITHUB_OUTPUT
 
   build-kubespray-image:
     needs: output-variable
@@ -51,7 +52,14 @@ jobs:
         ghcr_token=$(curl https://ghcr.io/token\?scope\="repository:${{ inputs.REPO }}/kubespray:pull" | jq '.token' | tr -d '"')
         skopeo list-tags --registry-token ${ghcr_token} docker://ghcr.io/${{ inputs.REPO }}/kubespray | jq '.Tags' | tr -d '[",]' > tags
         if grep -q ${commit_short_sha} tags; then
-          echo "need_rebuild=false" >>$GITHUB_OUTPUT
+          late_img_dockerfile_commit=${{ needs.output-variable.outputs.dockerfile_commit }}
+          prev_img_dockerfile_commit=$(skopeo inspect docker://ghcr.io/${{ inputs.REPO }}/kubespray:${commit_short_sha} | jq '.Labels."io.kubean.dockerfile-commit"')
+          echo ">>>> late_img_dockerfile_commit: ${late_img_dockerfile_commit}"
+          echo ">>>> prev_img_dockerfile_commit: ${prev_img_dockerfile_commit}"
+          if [[ ${late_img_dockerfile_commit} == ${prev_img_dockerfile_commit} ]]; then
+            echo "The dockerfile of the image with the same tag has not changed, no need to rebuild"
+            echo "need_rebuild=false" >>$GITHUB_OUTPUT
+          fi
         fi
 
     - uses: actions/checkout@v3
@@ -83,6 +91,7 @@ jobs:
         file: build/images/kubespray/Dockerfile
         build-args: |
           SPRAY_REF=${{ inputs.SPRAY_REF }}
+          DOCKERFILE_COMMIT=${{ needs.output-variable.outputs.dockerfile_commit }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         push: true
         provenance: false

--- a/build/images/kubespray/Dockerfile
+++ b/build/images/kubespray/Dockerfile
@@ -52,6 +52,11 @@ RUN ANSIBLE_CORE_VERSION=$( pip show -V ansible-core | grep Version: | awk '{pri
         fi
 
 FROM scratch
+
+ARG DOCKERFILE_COMMIT
+
+LABEL io.kubean.dockerfile-commit=${DOCKERFILE_COMMIT}
+
 COPY --from=spray-build / /
 
 ENV ANSIBLE_CONFIG=/kubespray/ansible.cfg


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The judgment criteria for rebuilding past images have vulnerabilities. When the commit of the upstream kubespray remains unchanged, but there are updates in the Dockerfile of the image, a rebuild should be triggered. However, in reality, it does not happen.



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
