### PR TITLE
Supplement centos in os pkgs matrix

### DIFF
--- a/.github/workflows/os-pkgs-matrix.json
+++ b/.github/workflows/os-pkgs-matrix.json
@@ -1,4 +1,5 @@
 [
+  { "name": "centos7", "dockerfile":"build/os-packages/Dockerfile.centos7"},
   { "name": "redhat7", "dockerfile":"build/os-packages/Dockerfile.redhat7"},
   { "name": "redhat8", "dockerfile":"build/os-packages/Dockerfile.redhat8"},
   { "name": "redhat9", "dockerfile":"build/os-packages/Dockerfile.redhat9"},


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When optimizing OS PKGS to build CI, the construct of Centos7 was omitted. Here is a supplement to this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
