### PR TITLE
update rhel8 os package

### DIFF
--- a/build/os-packages/Dockerfile.redhat8
+++ b/build/os-packages/Dockerfile.redhat8
@@ -1,21 +1,17 @@
-FROM centos:8 as os-redhat8
+FROM rockylinux:8 as os-redhat8
 ARG OS_VERSION=8
-ARG BUILD_TOOLS="yum-utils createrepo epel-release wget"
-
-RUN ARCH=$(uname -m) \
-    && dnf --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos -y \
-    && dnf distro-sync -y \
-    && dnf install -q -y ${BUILD_TOOLS} \
-    && dnf install -q -y http://mirror.centos.org/centos/8-stream/AppStream/${ARCH}/os/Packages/modulemd-tools-0.7-6.el8.noarch.rpm \
-    && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
-    && dnf makecache
+ARG BUILD_TOOLS="yum-utils createrepo epel-release wget modulemd-tools findutils"
 
 WORKDIR /redhat/$OS_VERSION/os
 COPY build/os-packages/packages.yml .
+COPY build/os-packages/repos/centos8.repo /etc/yum.repos.d/
 COPY --from=mikefarah/yq:4.30.8 /usr/bin/yq /usr/bin/yq
 RUN yq eval '.common[],.yum[],.redhat8[]' packages.yml > packages.list
 
 RUN ARCH=$(uname -m) \
+    && dnf install -q -y ${BUILD_TOOLS} \
+    && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
+    && dnf makecache \
     && sort -u packages.list | xargs repotrack --destdir ${ARCH} \
     && createrepo_c ${ARCH} \
     && repo2module -s stable ${ARCH} ${ARCH}/modules.yaml \

--- a/build/os-packages/repos/centos8.repo
+++ b/build/os-packages/repos/centos8.repo
@@ -1,0 +1,5 @@
+[centos8-appstream]
+name=Centos Linux 8 - AppStream
+baseurl=https://dl.rockylinux.org/vault/centos/8-stream/AppStream/$basearch/os/
+gpgcheck=0
+enabled=1


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
https://github.com/kubean-io/kubean/actions/runs/9480615036/job/26121701297
```
> [linux/amd64 os-redhat8 2/7] RUN ARCH=$(uname -m)     && dnf --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos -y     && dnf distro-sync -y     && dnf install -q -y yum-utils createrepo epel-release wget     && dnf install -q -y [http://mirror.centos.org/centos/8-stream/AppStream/${ARCH}/os/Packages/modulemd-tools-0.7-6.el8.noarch.rpm](http://mirror.centos.org/centos/8-stream/AppStream/$%7BARCH%7D/os/Packages/modulemd-tools-0.7-6.el8.noarch.rpm)     && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo     && dnf makecache:
0.768 CentOS Linux 8 - Extras                          18 kB/s | 7.9 kB     00:00    
0.769 Errors during downloading metadata for repository 'extras':
0.769   - Status code: 404 for http://mirror.centos.org/centos/8/extras/x86_64/os/repodata/repomd.xml (IP: 65.181.111.3)
0.771 Error: Failed to download metadata for repo 'extras': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```


The majority of the yum repos in the `centos:8` image have been deprecated and can no longer provide support for building OS packages. At the moment, `rockylinux:8` appears to be a good replacement option to succeed `centos:8`.

CI Verification Results:  https://github.com/ErikJiang/kubean/actions/runs/9496080733/job/26169720371

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
