### PR TITLE
Clean os pkgs for rhel7

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.52.2
+          version: v1.59.1
           args: --timeout=10m
 
       - name: ansible-lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,7 +139,6 @@ linters:
     - tagliatelle              # Checks the struct tags.
   enable:
     - asciicheck               # Simple linter to check that your code does not contain non-ASCII identifiers
-    - deadcode                 # Finds unused code
     - depguard                 # Go linter that checks if package imports are in a list of acceptable packages
     - dogsled                  # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
     - dupl                     # Tool for code clone detection
@@ -152,7 +151,6 @@ linters:
     - goprintffuncname         # Checks that printf-like functions are named with `f` at the end
     - gosimple                 # Linter for Go source code that specializes in simplifying a code
     - govet                    # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ifshort                  # Checks that your code uses short syntax for if-statements whenever possible
     - importas                 # Enforces consistent import aliases
     - ineffassign              # Detects when assignments to existing variables are not used
     - makezero                 # Finds slice declarations with non-zero initial length
@@ -165,13 +163,11 @@ linters:
     - revive                   # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
     - rowserrcheck             # checks whether Err of rows is checked successfully
     - staticcheck              # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
-    - structcheck              # Finds unused struct fields
     - stylecheck               # Stylecheck is a replacement for golint
     - thelper                  # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     - typecheck                # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert                # Remove unnecessary type conversions
     - unused                   # Checks Go code for unused constants, variables, functions and types
-    - varcheck                 # Finds unused global variables and constants
     - whitespace               # Tool for detection of leading and trailing whitespace
     - godot                    # Check if comments end in a period
 

--- a/build/os-packages/Dockerfile.redhat7
+++ b/build/os-packages/Dockerfile.redhat7
@@ -1,6 +1,7 @@
 FROM oraclelinux:7.9 as os-redhat7
 ARG OS_VERSION=7Server
 ARG BUILD_TOOLS="yum-utils createrepo wget"
+ARG PKGS_IN_ISO="selinux-policy-targeted policycoreutils-python iptables libcgroup libnetfilter_conntrack libseccomp libselinux-utils"
 
 RUN rm -rf /etc/yum.repos.d/{virt-ol7,uek-ol7,oracle-linux-ol7}.repo \
     && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
@@ -8,7 +9,8 @@ RUN rm -rf /etc/yum.repos.d/{virt-ol7,uek-ol7,oracle-linux-ol7}.repo \
     && yum-config-manager --disable ol7_UEKR* \
     && yum-config-manager --enable ol7_latest ol7_addons ol7_developer ol7_developer_EPEL docker-ce-stable \
     && yum makecache \
-    && yum install -q -y ${BUILD_TOOLS}
+    && yum install -q -y ${BUILD_TOOLS} \
+    && yum install -y ${PKGS_IN_ISO}
 
 WORKDIR /redhat/$OS_VERSION/os
 COPY build/os-packages/packages.yml .

--- a/build/os-packages/packages.yml
+++ b/build/os-packages/packages.yml
@@ -53,7 +53,6 @@ rocky9:
 kylinv10:
   - container-selinux
   - socat
-  - libselinux-python
   - libselinux-devel
   - python3-libselinux
   - containerd.io-1.6.28-3.1.el8


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind enhancement

#### What this PR does / why we need it:

``` sh
[root@demo ~]# yum install container-selinux
Loaded plugins: product-id, search-disabled-repos, subscription-manager

This system is not registered with an entitlement server. You can use subscription-manager to register.

Resolving Dependencies
--> Running transaction check
---> Package container-selinux.noarch 2:2.119.2-1.911c772.el7_8 will be installed
--> Processing Dependency: policycoreutils-python for package: 2:container-selinux-2.119.2-1.911c772.el7_8.noarch
--> Running transaction check
---> Package policycoreutils-python.x86_64 0:2.5-34.0.1.el7 will be installed
--> Processing Dependency: policycoreutils = 2.5-34.0.1.el7 for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: setools-libs >= 3.3.8-4 for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: libsemanage-python >= 2.5-14 for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: audit-libs-python >= 2.1.3-4 for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: python-IPy for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: libqpol.so.1(VERS_1.4)(64bit) for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
[extension-0]
--> Processing Dependency: libqpol.so.1(VERS_1.2)(64bit) for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: libcgroup for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: libapol.so.4(VERS_4.0)(64bit) for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: checkpolicy for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: libqpol.so.1()(64bit) for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Processing Dependency: libapol.so.4()(64bit) for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
--> Running transaction check
---> Package audit-libs-python.x86_64 0:2.8.5-4.el7 will be installed
---> Package checkpolicy.x86_64 0:2.5-8.el7 will be installed
---> Package libcgroup.x86_64 0:0.41-21.el7 will be installed
---> Package libsemanage-python.x86_64 0:2.5-14.el7 will be installed
---> Package policycoreutils-python.x86_64 0:2.5-34.0.1.el7 will be installed
--> Processing Dependency: policycoreutils = 2.5-34.0.1.el7 for package: policycoreutils-python-2.5-34.0.1.el7.x86_64
---> Package python-IPy.noarch 0:0.75-6.el7 will be installed
---> Package setools-libs.x86_64 0:3.3.8-4.el7 will be installed
--> Finished Dependency Resolution
Error: Package: policycoreutils-python-2.5-34.0.1.el7.x86_64 (extension-0)
           Requires: policycoreutils = 2.5-34.0.1.el7
           Installed: policycoreutils-2.5-34.el7.x86_64 (@anaconda/7.9)
               policycoreutils = 2.5-34.el7
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest

[root@demo ~]# yum --showduplicates list policycoreutils-python
Loaded plugins: product-id, search-disabled-repos, subscription-manager

This system is not registered with an entitlement server. You can use subscription-manager to register.

Available Packages
policycoreutils-python.x86_64    2.5-34.el7            extension-1
policycoreutils-python.x86_64    2.5-34.0.1.el7        extension-0
```
Clean up unnecessary packages in the RHEL 7 package, as they already exist in the ISO, to avoid conflicts from their coexistence.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
