### PR TITLE
[Test]Remove check for /proc/sys/net/ipv4/tcp_tw_recycle

### DIFF
--- a/test/kubean_sonobouy_nightlye2e/kubean_cluster_sonobouy_test.go
+++ b/test/kubean_sonobouy_nightlye2e/kubean_cluster_sonobouy_test.go
@@ -96,6 +96,7 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 		// check network configuration:
 		// cat /proc/sys/net/ipv4/ip_forward: 1
 		// cat /proc/sys/net/ipv4/tcp_tw_recycle: 0
+		// The tcp_tw_recycle configuration has been removed from Linux kernel version 4.12.
 		ginkgo.It("do network configurations checking", func() {
 			masterCmd := tools.RemoteSSHCmdArrayByPasswd(password, []string{masterSSH, "cat", "/proc/sys/net/ipv4/ip_forward"})
 			workerCmd := tools.RemoteSSHCmdArrayByPasswd(password, []string{workerSSH, "cat", "/proc/sys/net/ipv4/ip_forward"})
@@ -105,15 +106,6 @@ var _ = ginkgo.Describe("e2e test cluster 1 master + 1 worker sonobouy check", f
 			workerOut, _ := tools.NewDoCmd("sshpass", workerCmd...)
 			klog.Info("out: ", workerOut.String())
 			gomega.Expect(workerOut.String()).Should(gomega.ContainSubstring("1"))
-
-			masterCmd = tools.RemoteSSHCmdArrayByPasswd(password, []string{masterSSH, "cat", "/proc/sys/net/ipv4/tcp_tw_recycle"})
-			workerCmd = tools.RemoteSSHCmdArrayByPasswd(password, []string{workerSSH, "cat", "/proc/sys/net/ipv4/tcp_tw_recycle"})
-			masterOut, _ = tools.NewDoCmd("sshpass", masterCmd...)
-			klog.Info("out: ", masterOut.String())
-			gomega.Expect(masterOut.String()).Should(gomega.ContainSubstring("0"))
-			workerOut, _ = tools.NewDoCmd("sshpass", workerCmd...)
-			klog.Info("out: ", workerOut.String())
-			gomega.Expect(workerOut.String()).Should(gomega.ContainSubstring("0"))
 		})
 
 		ginkgo.It("Support CNI: Calico", func() {


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind e2e-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind enhancement
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind design
/kind regression
-->

#### What this PR does / why we need it:
The tcp_tw_recycle configuration has been removed from Linux kernel version 4.12.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
