### PR TITLE
fix kubectl download url & bump kubespray to a4843ea

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -55,8 +55,7 @@ jobs:
       - name: static check
         uses: golangci/golangci-lint-action@v7
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.59.1
+          version: v2.0.2
           args: --timeout=10m
 
       - name: ansible-lint

--- a/build/images/kubespray/Dockerfile
+++ b/build/images/kubespray/Dockerfile
@@ -31,7 +31,7 @@ RUN ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -
        else \
          KUBE_VERSION=$(sed -n 's/^kube_version: //p' roles/kubespray-defaults/defaults/main.yaml); \
        fi \
-    && curl -LO https://dl.k8s.io/release/$KUBE_VERSION/bin/linux/$ARCH/kubectl \
+    && curl -LO https://dl.k8s.io/release/v$KUBE_VERSION/bin/linux/$ARCH/kubectl \
     && curl -LO https://github.com/mikefarah/yq/releases/download/v4.44.2/yq_linux_$ARCH \
     && chmod a+x kubectl yq_linux_$ARCH \
     && mv kubectl /usr/local/bin/kubectl \

--- a/version.yml
+++ b/version.yml
@@ -1,2 +1,2 @@
-kubespray_version: f3682d85d32329a8b32048a307547d0a384f8821
+kubespray_version: a4843eaf5e046b245afeda90937891e2935d6b4e
 kubernetes_version: 1.31.6


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

![image](https://github.com/user-attachments/assets/f2e29902-9a11-4741-85e7-28a25b6faa87)

In the download URL of kubectl, the version string lacks the v character prefix.

Changes see https://github.com/kubernetes-sigs/kubespray/compare/f3682d8..a4843ea

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
