### PR TITLE
add kernel version compatibility check for kubernetes

### DIFF
--- a/playbooks/check-kernel-compatibility.yml
+++ b/playbooks/check-kernel-compatibility.yml
@@ -1,0 +1,44 @@
+---
+- name: Check kernel compatibility
+  hosts: k8s_cluster,etcd
+  gather_facts: false
+  become: true
+
+  tasks:
+    - name: Gather kernel facts
+      setup:
+        gather_subset:
+          - '!all'
+          - '!min'
+          - hardware
+        filter:
+          - ansible_kernel
+        gather_timeout: 5
+
+    - name: Compare kernel and kubernetes versions
+      set_fact:
+        kernel_version: "{{ ansible_kernel.split('-')[0] }}"
+        kernel_version_incompatible: >-
+          {{
+            (ansible_kernel.split('-')[0] is version('4.19', '<')) and
+            (kube_version is version('1.32.0', '>='))
+          }}
+
+    - name: Check if SystemVerification is configured
+      set_fact:
+        system_verification_configured: >-
+          {{
+            kubeadm_ignore_preflight_errors is defined and
+            kubeadm_ignore_preflight_errors is sequence and
+            'SystemVerification' in kubeadm_ignore_preflight_errors
+          }}
+
+    - name: Display kernel compatibility warning and exit
+      fail:
+        msg: >-
+          ERROR: Kernel version {{ kernel_version }} is too low for Kubernetes {{ kube_version }}.
+          Either upgrade to kernel 4.19+ (recommended)
+          or add 'SystemVerification' to kubeadm_ignore_preflight_errors (experimental).
+      when:
+        - kernel_version_incompatible | bool
+        - not (system_verification_configured | default(false))

--- a/playbooks/precheck.yml
+++ b/playbooks/precheck.yml
@@ -161,6 +161,8 @@
       when:
         - check_node_time_sync
 
+- import_playbook: check-kernel-compatibility.yml
+
 - hosts: localhost
   gather_facts: false
   vars:


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind enhancement

#### What this PR does / why we need it:

![image](https://github.com/user-attachments/assets/bfadf186-17e6-44ee-a631-2d1191942242)

Add pre-check logic to verify if the host kernel version is compatible with target kubernetes version:
- Check if kernel version meets minimum requirement (4.19) for k8s 1.32.0+
- Support bypass via SystemVerification in kubeadm_ignore_preflight_errors
- Fail with clear upgrade instructions if requirements not met

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
