### PR TITLE
fix manifest calico version no_arch

### DIFF
--- a/artifacts/gen_airgap_crs.py
+++ b/artifacts/gen_airgap_crs.py
@@ -24,7 +24,7 @@ COMPONENTS_KEYS = [
   {"name": "runc", "checksumsKey": "runc_checksums.amd64"},
   {"name": "kube", "checksumsKey": "kubelet_checksums.amd64"},
   {"name": "cni", "checksumsKey": "cni_binary_checksums.amd64"},
-  {"name": "calico", "checksumsKey": "calico_crds_archive_checksums"},
+  {"name": "calico", "checksumsKey": "calicoctl_binary_checksums.amd64"},
   {"name": "containerd", "checksumsKey": "containerd_archive_checksums.amd64"},
 ]
 


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind enhancement
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind design
/kind regression
-->

#### What this PR does / why we need it:

fix https://github.com/kubean-io/kubean-helm-chart/blob/kubean-v0.24.0/charts/kubean/templates/manifest.cr.yaml#L140-L143

![image](https://github.com/user-attachments/assets/ac20ccea-2120-4425-9edc-bc56687476f6)



Since  kubespray

`calico_version: "{{ (calicoctl_binary_checksums['amd64'] | dict2items)[0].key }}"`

we change `calico_crds_archive_checksums` to `calicoctl_binary_checksums`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
