### PR TITLE
fix: avoid multiple apt-cache updates when adding repositories

### DIFF
--- a/playbooks/enable-repo.yml
+++ b/playbooks/enable-repo.yml
@@ -99,11 +99,26 @@
         repo: "{{ item }}"
         state: present
         filename: "{{ repo_name }}"
+        update_cache: false
       with_items: "{{ repo_list }}"
+      register: repo_result
       when:
         - ansible_pkg_mgr == 'apt'
         - not deb_repo_data.stat.exists and ( repo_list | length > 0 )
         - not undo|default(false)|bool
+
+    - name: Update apt cache once
+      apt:
+        update_cache: true
+      register: apt_update_result
+      retries: 3
+      delay: 5
+      until: apt_update_result is success
+      when:
+        - ansible_pkg_mgr == 'apt'
+        - not deb_repo_data.stat.exists and ( repo_list | length > 0 )
+        - not undo|default(false)|bool
+        - repo_result is changed
 
     # Uninstall
 


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Optimize apt repository configuration by:
- Disable automatic cache updates during apt_repository tasks
- Add a single apt cache update after all repositories are added
- Fix potential apt lock issues when adding multiple repositories

This change improves performance and reliability of the repository setup process.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
