### PR TITLE
fix: include nerdctl binary in airgap packages

### DIFF
--- a/artifacts/airgap_patch.py
+++ b/artifacts/airgap_patch.py
@@ -139,7 +139,7 @@ def get_manifest_data():
 
 def get_other_required_keywords(manifest_dict):
     other_required_keywords = [
-        "crun", "runsc", "cri-dockerd", "yq", "nginx", "k8s-dns-node-cache", "cluster-proportional-autoscaler"]
+        "nerdctl", "crun", "runsc", "cri-dockerd", "yq", "nginx", "k8s-dns-node-cache", "cluster-proportional-autoscaler"]
     manifest_keys = [ key for key in manifest_dict]
     keys_range = [ key for key in KEYWORDS]
     list_diff = list(set(keys_range) - set(manifest_keys))


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind enhancement

#### What this PR does / why we need it:

Add nerdctl to the other_required_keywords list in airgap_patch.py to ensure the nerdctl binary is included in generated airgap packages.

This fixes the missing nerdctl binary issue in offline installations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1533

#### Special notes for your reviewer:
