### PR TITLE
feat: add ubuntu 24.04 (noble) support for airgap installations

### DIFF
--- a/.github/workflows/os-pkgs-matrix.json
+++ b/.github/workflows/os-pkgs-matrix.json
@@ -12,5 +12,6 @@
   { "name": "oracle9", "dockerfile":"build/os-packages/Dockerfile.oracle9"},
   { "name": "tencent31", "dockerfile":"build/os-packages/Dockerfile.tencent31"},
   { "name": "ubuntu2004", "dockerfile":"build/os-packages/Dockerfile.ubuntu2004"},
-  { "name": "ubuntu2204", "dockerfile":"build/os-packages/Dockerfile.ubuntu2204"}
+  { "name": "ubuntu2204", "dockerfile":"build/os-packages/Dockerfile.ubuntu2204"},
+  { "name": "ubuntu2404", "dockerfile":"build/os-packages/Dockerfile.ubuntu2404"}
 ]

--- a/artifacts/gen_repo_conf.sh
+++ b/artifacts/gen_repo_conf.sh
@@ -112,7 +112,7 @@ function get_apt_codename_from_os_release() {
 
 function get_apt_codename_from_iso() {
   for codename in $(find ${ISO_MOUNT_PATH}/dists/ -maxdepth 1 -type d -exec basename {} \;); do
-    [[ "${codename}" =~ xenial|bionic|focal|jammy ]] && { echo "${codename}"; return; }
+    [[ "${codename}" =~ xenial|bionic|focal|jammy|noble ]] && { echo "${codename}"; return; }
   done
   echo $(get_apt_codename_from_os_release)
 }

--- a/build/os-packages/Dockerfile.ubuntu2204
+++ b/build/os-packages/Dockerfile.ubuntu2204
@@ -16,13 +16,13 @@ ARG PACKAGES_PREFIX=dists/${OS_VERSION}/main/binary-${TARGETARCH}
 
 COPY build/os-packages/packages.yml ./${PACKAGES_PREFIX}/packages.yml
 
-COPY --from=mikefarah/yq:4.30.8 /usr/bin/yq /usr/bin/yq
+COPY --from=mikefarah/yq:4.45.3 /usr/bin/yq /usr/bin/yq
 # The version of docker-ce-cli should be consistent with that of docker-ce.
 # See https://github.com/kubean-io/kubean/issues/1156
 RUN while read -r line; do \
       if [[ $line == docker-ce* ]]; then \
           version=$(echo $line | cut -d'=' -f2); \
-          line="$line docker-ce-cli=$version containerd.io=1.6.28-1"; \
+          line="$line docker-ce-cli=$version containerd.io=1.6.32-1"; \
       fi; \
       apt-get install --reinstall --print-uris $line | egrep "https|http" | awk -F "'" '{print $2}' >> urls.list; \
     done <<<"$(yq eval '.common[],.apt[],.ubuntu2204[]' ./${PACKAGES_PREFIX}/packages.yml | sort -u)" \

--- a/build/os-packages/Dockerfile.ubuntu2404
+++ b/build/os-packages/Dockerfile.ubuntu2404
@@ -1,6 +1,6 @@
-FROM ubuntu:focal as os-focal
+FROM ubuntu:noble as os-noble
 ARG TARGETARCH
-ARG OS_VERSION=focal
+ARG OS_VERSION=noble
 ARG DEP_PACKAGES="apt-transport-https ca-certificates curl wget gnupg dpkg-dev"
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh \
@@ -25,7 +25,7 @@ RUN while read -r line; do \
           line="$line docker-ce-cli=$version containerd.io=1.6.32-1"; \
       fi; \
       apt-get install --reinstall --print-uris $line | egrep "https|http" | awk -F "'" '{print $2}' >> urls.list; \
-    done <<<"$(yq eval '.common[],.apt[],.ubuntu2004[]' ./${PACKAGES_PREFIX}/packages.yml | sort -u)" \
+    done <<<"$(yq eval '.common[],.apt[],.ubuntu2404[]' ./${PACKAGES_PREFIX}/packages.yml | sort -u)" \
     && sort -u urls.list > ./${PACKAGES_PREFIX}/packages.list \
     && rm -f urls.list
 
@@ -33,4 +33,4 @@ RUN wget -q -x -P ${PACKAGES_PREFIX} -i ./${PACKAGES_PREFIX}/packages.list \
     && dpkg-scanpackages --multiversion ${PACKAGES_PREFIX} | gzip -9c > ${PACKAGES_PREFIX}/Packages.gz
 
 FROM scratch
-COPY --from=os-focal /ubuntu /resources/ubuntu
+COPY --from=os-noble /ubuntu /resources/ubuntu

--- a/build/os-packages/README.md
+++ b/build/os-packages/README.md
@@ -14,4 +14,5 @@
 | [Tencentos 3.1](https://www.tencentcloud.com/document/product/213/40223) | `amd64` / `arm64` | `containerd` | [Automatic build on release](https://github.com/kubean-io/kubean/releases) |
 | [Ubuntu 20.04](https://ubuntu.com/)                                      | `amd64` / `arm64` | `docker` / `containerd` | [Automatic build on release](https://github.com/kubean-io/kubean/releases) |
 | [Ubuntu 22.04](https://ubuntu.com/)                                      | `amd64` / `arm64` | `docker` / `containerd` | [Automatic build on release](https://github.com/kubean-io/kubean/releases) |
+| [Ubuntu 24.04](https://ubuntu.com/)                                      | `amd64` / `arm64` | `docker` / `containerd` | [Automatic build on release](https://github.com/kubean-io/kubean/releases) |
 | [UnionTech V20](https://www.chinauos.com/) (experimental)                | `amd64` | `containerd` | [Manual build using scripts](./others/uos_v20/) |

--- a/build/os-packages/check_rebuild_pkgs.sh
+++ b/build/os-packages/check_rebuild_pkgs.sh
@@ -45,7 +45,7 @@ if [[ "${OS_NAME}" =~ ^(centos|kylin|redhat|rocky|oracle|tencent|openeuler).* ]]
   fi
 fi
 
-# ubuntu2004 / ubuntu2204
+# ubuntu2004 / ubuntu2204 / ubuntu 2404
 if [[ "${OS_NAME}" == "ubuntu"* ]]; then
   late_digest=$(echo "${late_packages_yml}" | yq eval ".common[],.apt[],.${OS_NAME}[]" | sort | sha1sum | awk '{print $1}')
   prev_digest=$(echo "${prev_packages_yml}" | yq eval ".common[],.apt[],.${OS_NAME}[]" | sort | sha1sum | awk '{print $1}')

--- a/build/os-packages/packages.yml
+++ b/build/os-packages/packages.yml
@@ -8,6 +8,9 @@ apt:
   - unzip
   - ebtables
   - ntp
+  - bash-completion
+  - iputils-ping
+  - rsync
 
 common:
   - sshpass
@@ -77,16 +80,25 @@ kylin:
 
 # https://download.docker.com/linux/ubuntu/
 ubuntu2004:
-  - containerd.io=1.6.28-1
   - containerd.io=1.6.32-1
-  - docker-ce=5:24.0.9-1~ubuntu.20.04~focal
+  - containerd.io=1.7.25-1
   - docker-ce=5:26.1.2-1~ubuntu.20.04~focal
+  - docker-ce=5:27.4.1-1~ubuntu.20.04~focal
+  - docker-ce=5:28.0.2-1~ubuntu.20.04~focal
 
 ubuntu2204:
-  - containerd.io=1.6.28-1
   - containerd.io=1.6.32-1
-  - docker-ce=5:24.0.9-1~ubuntu.22.04~jammy
+  - containerd.io=1.7.25-1
   - docker-ce=5:26.1.2-1~ubuntu.22.04~jammy
+  - docker-ce=5:27.4.1-1~ubuntu.22.04~jammy
+  - docker-ce=5:28.0.2-1~ubuntu.22.04~jammy
+
+ubuntu2404:
+  - containerd.io=1.6.32-1
+  - containerd.io=1.7.25-1
+  - docker-ce=5:26.1.2-1~ubuntu.24.04~noble
+  - docker-ce=5:27.4.1-1~ubuntu.24.04~noble
+  - docker-ce=5:28.0.2-1~ubuntu.24.04~noble
 
 openeuler:
   - socat


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add Ubuntu 24.04 (Noble Numbat) support for airgap/offline Kubernetes deployments:
- Create Dockerfile.ubuntu2404 to build OS packages for offline installations
- Add ubuntu2404 to os-pkgs-matrix.json for CI/CD pipeline
- Configure Ubuntu 24.04 specific packages in packages.yml (containerd, docker-ce)
- Update check_rebuild_pkgs.sh to handle ubuntu2404 package verification
- Ensure gen_repo_conf.sh properly configures apt repositories for Noble

This enables Kubernetes deployment on Ubuntu 24.04 in completely airgapped environments.

![image](https://github.com/user-attachments/assets/6ff63e22-0892-4924-b1f7-ceae9eae073d)

![image](https://github.com/user-attachments/assets/c4a553f6-ee63-4349-95c8-231cd888e1af)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:



