### PR TITLE
clean cilium_kube_proxy_replacement

### DIFF
--- a/hack/network_testcase.sh
+++ b/hack/network_testcase.sh
@@ -88,7 +88,6 @@ function kubean_cilium_cluster_e2e() {
     yq -i '.kube_service_addresses = "10.88.0.0/16"'  $groupVarYml
     yq -i '.kube_pods_subnet = "192.88.128.0/20"'  $groupVarYml
     yq -i '.kube_network_node_prefix = 24'  $groupVarYml
-    yq -i '.cilium_kube_proxy_replacement = "partial"'  $groupVarYml
     #### End: write back group vars to VarsConfCM.yml
     yamlUtil::update_groupVars
     prepare_sonobuoy

--- a/hack/run-network-e2e.sh
+++ b/hack/run-network-e2e.sh
@@ -105,8 +105,6 @@ sed -i "s/kube_network_plugin: calico/kube_network_plugin: cilium/" "${dest_conf
 ##set  kube_service_addresses: 10.88.0.0/16    kube_pods_subnet: 192.88.128.0/20
 sed -i "s/10.96.0.0\/12/10.88.0.0\/16/" "${dest_config_path}"/vars-conf-cm.yml
 sed -i "s/192.168.128.0/192.88.128.0/" "${dest_config_path}"/vars-conf-cm.yml
-##add this line to set cilium_kube_proxy_replacement: partial, if kubespray update the cilium_kube_proxy_replacement default value to partial, this line can be deleted
-sed -i "$ a\    cilium_kube_proxy_replacement: partial" "${dest_config_path}"/vars-conf-cm.yml
 ##Switch the namespace of configmap to new_kubean_namespace
 sed -i "s/namespace: kubean-system/namespace: ${new_kubean_namespace}/" "${dest_config_path}"/hosts-conf-cm.yml
 sed -i "s/namespace: kubean-system/namespace: ${new_kubean_namespace}/" "${dest_config_path}"/vars-conf-cm.yml


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

```
TASK [network_plugin/cilium : Cilium | Install] ********************************
fatal: [node1]: FAILED! => {"changed": true, "cmd": ["/usr/local/bin/cilium", "install", "--version", "1.17.3", "-f", "/etc/kubernetes/cilium-values.yaml"], "delta": "0:00:01.812761", "end": "2025-06-05 02:10:18.420518", "msg": "non-zero return code", "rc": 1, "start": "2025-06-05 02:10:16.607757", "stderr": "\nError: Unable to install Cilium: execution error at (cilium/templates/cilium-configmap.yaml:73:5): kubeProxyReplacement must be explicitly set to a valid value (true or false) to continue.", "stderr_lines": ["", "Error: Unable to install Cilium: execution error at (cilium/templates/cilium-configmap.yaml:73:5): kubeProxyReplacement must be explicitly set to a valid value (true or false) to continue."], "stdout": "ℹ️  Using Cilium version 1.17.3\nℹ️  Using cluster name \"default\"\n🔮 Auto-detected kube-proxy has been installed", "stdout_lines": ["ℹ️  Using Cilium version 1.17.3", "ℹ️  Using cluster name \"default\"", "🔮 Auto-detected kube-proxy has been installed"]}
```

Clear the variable configuration of `cilium_kube_proxy_replacement: partial` in the test cases. This configuration is the parameter of the old version of cilium. The new version is configured using the bool type and defaults to false. Therefore, clearing such parameters is the best course of action.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
