### PR TITLE
Fix(CI): Ensure correct branch SHA1 is fetched in manual release workflow

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -60,8 +60,6 @@ jobs:
 
       - name: ansible-lint
         uses: ansible/ansible-lint@v25.6.1
-        with:
-          working_directory: "playbooks/"
 
       - name: Run Trivy vulnerability scanner in fs mode
         uses: aquasecurity/trivy-action@0.32.0

--- a/.github/workflows/manual-kubespray-release.yaml
+++ b/.github/workflows/manual-kubespray-release.yaml
@@ -29,7 +29,7 @@ jobs:
         INPUTS_SPRAY_BRANCH=${{ inputs.branch }}
         INPUTS_COMMIT_SHA1=${{ inputs.commit_SHA1 }}
 
-        SPRAY_BRANCH_SHA1=`git ls-remote -h https://github.com/kubernetes-sigs/kubespray.git ${INPUTS_SPRAY_BRANCH} | awk '{print $1}'`
+        SPRAY_BRANCH_SHA1=`git ls-remote -h https://github.com/kubernetes-sigs/kubespray.git refs/heads/${INPUTS_SPRAY_BRANCH} | awk '{print $1}'`
         if [[ -z "${SPRAY_BRANCH_SHA1}" ]]; then
           echo "The specified branch '${INPUTS_SPRAY_BRANCH}' is nonexistent!" && exit 1
         fi


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The git ls-remote command in the manual kubespray release workflow was not specific enough and could retrieve the SHA1 from an incorrect branch if another branch name contained the target branch name as a substring.

For example, when targeting the release-2.28 branch, the old command might incorrectly match component_hash_update/release-2.28:
```
$ git ls-remote -h https://github.com/kubernetes-sigs/kubespray.git release-2.28
c13134b88117bc35d05b77c26e1cc5f80aea5624	refs/heads/component_hash_update/release-2.28
2d0cc2b4ea1a5f578300536d711d10c626c390bb	refs/heads/release-2.28
```
This PR fixes the issue by specifying the full ref path refs/heads/, which ensures the command always resolves to the exact branch head, preventing ambiguity.
```
$ git ls-remote -h https://github.com/kubernetes-sigs/kubespray.git refs/heads/release-2.28
2d0cc2b4ea1a5f578300536d711d10c626c390bb	refs/heads/release-2.28
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1589

#### Special notes for your reviewer:
