### PR TITLE
fix PR e2e image

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -114,7 +114,7 @@ jobs:
         run: |
           ORGANIZATION_NAME=$(echo ${GITHUB_REPOSITORY}| awk -F "/" '{print $1}')
           echo "REPO=${ORGANIZATION_NAME,,}" >> ${GITHUB_ENV}
-          echo "KUBESPRAY_TAG=$(awk '/kubespray_version/ {printf("%.7s",$2)}' version.yml)" >> ${GITHUB_ENV}
+          echo "KUBESPRAY_TAG=$(awk '/kubespray_version/ {printf("%.7s",$2)}' version.yml)-ansible9" >> ${GITHUB_ENV}
 
       - name: Echo env
         run: |


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Ansible9 is not specified for image builds for PR e2e verification, 
which can cause errors in target node python version compatibility issues 
when deploying clusters in low-version OS such as rocky8 environments.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
