### PR TITLE
Fix(spray-job): Replace facts.yml symlink to fix playbook import path

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -50,6 +50,7 @@ warn_list:
   - ignore-errors # Use failed_when and specify error conditions instead of using ignore_errors.
   - no-free-form  # Avoid using free-form when calling module actions.
 exclude_paths:
+  - playbooks/facts.yml
   - playbooks/disable-firewalld.yml
   - playbooks/config-for-kube-vip.yml
   - playbooks/mount-xfs-pquota.yml

--- a/build/images/spray-job/Dockerfile
+++ b/build/images/spray-job/Dockerfile
@@ -10,7 +10,4 @@ COPY playbooks/ /kubespray/
 # Add extra python packages and collections needed for the playbooks
 RUN python3 -m pip install toml
 RUN ansible-galaxy collection install sivel.toiletwater
-
-RUN ln -s playbooks/facts.yml facts.yml
-
 RUN apk add --no-cache openssl

--- a/playbooks/facts.yml
+++ b/playbooks/facts.yml
@@ -1,0 +1,3 @@
+---
+- name: Gather the facts
+  ansible.builtin.import_playbook: playbooks/facts.yml


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

```
ERROR! Unable to retrieve file contents
Could not find or access '/kubespray/boilerplate.yml' on the Ansible Controller.
```

The symlink for facts.yml in the spray-job container was causing path resolution issues for import_playbook.

This change replaces the symlink with a top-level facts.yml that correctly imports the playbook from the playbooks subdirectory, resolving the import path error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
