### PR TITLE
📖 Add KubeStellar Console guided install reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Kubean is a <a href="https://cncf.io/">Cloud Native Computing Foundation sandbox
 
 We created a [scenario](https://killercoda.com/kubean) on [killercoda](https://killercoda.com), which is an online platform for interactive technique learning. You can try it in there.
 
+### Guided install with KubeStellar Console
+
+[KubeStellar Console](https://console.kubestellar.io) offers a [guided installation mission for Kubean](https://console.kubestellar.io/missions/install-kubean) with step-by-step instructions, pre-flight checks, validation, troubleshooting tips, and rollback support.
+
 ### Local install
 
 1. Ensure that you have a Kubernetes cluster running, on which Helm is installed


### PR DESCRIPTION
## Summary

- Adds a reference to the [KubeStellar Console guided installation mission](https://console.kubestellar.io/missions/install-kubean) in the Quick Start section of the README
- Placed between the existing Killercoda tutorials and Local install subsections
- The guided install provides step-by-step instructions, pre-flight checks, validation, troubleshooting tips, and rollback support

Related: #1761

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify links to console.kubestellar.io resolve