### PR TITLE
fix golangci lint issue

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -55,7 +55,8 @@ jobs:
       - name: static check
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.0
+          install-mode: goinstall
+          version: v2.11.4
           args: --timeout=10m
 
       - name: install ansible requirements

--- a/hack/staticcheck.sh
+++ b/hack/staticcheck.sh
@@ -8,15 +8,17 @@ set -o nounset
 set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-GOLANGCI_LINT_VER="v2.1.0"
+GOLANGCI_LINT_VER="v2.11.4"
 
 cd "${REPO_ROOT}"
 source "hack/util.sh"
 
-# binary will be $(go env GOPATH)/bin/golangci-lint
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCI_LINT_VER
+# Build golangci-lint with the active Go toolchain so the binary stays compatible
+# with the Go version declared by this repository.
+GOLANGCI_LINT_BIN="$(go env GOPATH)/bin/golangci-lint"
+GOBIN="$(go env GOPATH)/bin" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_LINT_VER}
 
-if golangci-lint run --fix --verbose; then
+if "${GOLANGCI_LINT_BIN}" run --fix --verbose; then
   echo 'Congratulations!  All Go source files have passed staticcheck.'
 else
   echo # print one empty line, separate from warning messages.

--- a/pkg/controllers/cluster/controller_test.go
+++ b/pkg/controllers/cluster/controller_test.go
@@ -178,7 +178,7 @@ func TestCompareClusterConditions(t *testing.T) {
 func TestSortClusterOperationsByCreation(t *testing.T) {
 	controller := &Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -245,7 +245,7 @@ func Test_CleanExcessClusterOps(t *testing.T) {
 	OpsBackupNum := 5
 	controller := &Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -360,7 +360,7 @@ func Test_CleanExcessClusterOps(t *testing.T) {
 func Test_UpdateStatus(t *testing.T) {
 	controller := &Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -479,7 +479,7 @@ func TestReconcile(t *testing.T) {
 	genController := func() *Controller {
 		return &Controller{
 			Client:              newFakeClient(),
-			ClientSet:           clientsetfake.NewSimpleClientset(),
+			ClientSet:           clientsetfake.NewClientset(),
 			KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 			KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 		}
@@ -637,7 +637,7 @@ func TestReconcile(t *testing.T) {
 func TestStart(t *testing.T) {
 	controller := &Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -649,7 +649,7 @@ func TestStart(t *testing.T) {
 func TestSetupWithManager(t *testing.T) {
 	controller := &Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}

--- a/pkg/controllers/clusterops/controller_test.go
+++ b/pkg/controllers/clusterops/controller_test.go
@@ -437,7 +437,7 @@ func TestNewKubesprayJob(t *testing.T) {
 	os.Setenv("POD_NAMESPACE", "mynamespace")
 	controller := Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
 	}
 	clusterOps := &clusteroperationv1alpha1.ClusterOperation{}
@@ -524,7 +524,7 @@ func TestController_HookCustomAction(t *testing.T) {
 	configmapActionSource := clusteroperationv1alpha1.ConfigMapActionSource
 	controller := Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
 	}
 	clusterOps := &clusteroperationv1alpha1.ClusterOperation{}
@@ -728,7 +728,7 @@ func TestIsValidImageName(t *testing.T) {
 func TestUpdateStatusForLabel(t *testing.T) {
 	controller := Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
@@ -782,7 +782,7 @@ func TestUpdateStatusForLabel(t *testing.T) {
 func TestGetServiceAccountName(t *testing.T) {
 	controller := Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
@@ -847,7 +847,7 @@ func TestReconcile(t *testing.T) {
 	genController := func() *Controller {
 		return &Controller{
 			Client:                newFakeClient(),
-			ClientSet:             clientsetfake.NewSimpleClientset(),
+			ClientSet:             clientsetfake.NewClientset(),
 			KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 			KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 			InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
@@ -1248,7 +1248,7 @@ func TestReconcile(t *testing.T) {
 func TestCreateKubeSprayJob(t *testing.T) {
 	controller := &Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
@@ -1403,7 +1403,7 @@ func TestCreateKubeSprayJob(t *testing.T) {
 func Test_CheckConfigMapExist(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -1452,7 +1452,7 @@ func Test_CheckConfigMapExist(t *testing.T) {
 func Test_CheckSecretExist(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -1501,7 +1501,7 @@ func Test_CheckSecretExist(t *testing.T) {
 func Test_CheckClusterDataRef(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -1645,7 +1645,7 @@ func Test_CheckClusterDataRef(t *testing.T) {
 func Test_GetKuBeanCluster(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -1689,7 +1689,7 @@ func Test_GetKuBeanCluster(t *testing.T) {
 func Test_TrySuspendPod(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -1894,7 +1894,7 @@ func Test_GetRunningPodFromJob(t *testing.T) {
 	genController := func() Controller {
 		return Controller{
 			Client:              newFakeClient(),
-			ClientSet:           clientsetfake.NewSimpleClientset(),
+			ClientSet:           clientsetfake.NewClientset(),
 			KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 			KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 		}
@@ -1993,7 +1993,7 @@ func Test_CreateEntryPointShellConfigMap(t *testing.T) {
 	genController := func() Controller {
 		return Controller{
 			Client:              newFakeClient(),
-			ClientSet:           clientsetfake.NewSimpleClientset(),
+			ClientSet:           clientsetfake.NewClientset(),
 			KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 			KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 		}
@@ -2089,7 +2089,7 @@ func Test_CreateEntryPointShellConfigMap(t *testing.T) {
 func TestStart(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -2101,7 +2101,7 @@ func TestStart(t *testing.T) {
 func Test_FetchJobStatus(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -2304,7 +2304,7 @@ func Test_FetchJobStatus(t *testing.T) {
 func Test_CopyConfigMap(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -2373,7 +2373,7 @@ func Test_CopyConfigMap(t *testing.T) {
 func Test_CopySecret(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -2442,7 +2442,7 @@ func Test_CopySecret(t *testing.T) {
 func Test_BackUpDataRef(t *testing.T) {
 	controller := Controller{
 		Client:              newFakeClient(),
-		ClientSet:           clientsetfake.NewSimpleClientset(),
+		ClientSet:           clientsetfake.NewClientset(),
 		KubeanClusterSet:    clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet: clusteroperationv1alpha1fake.NewSimpleClientset(),
 	}
@@ -2679,7 +2679,7 @@ func Test_BackUpDataRef(t *testing.T) {
 func Test_ProcessKubeanOperationImage(t *testing.T) {
 	controller := Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
@@ -2724,7 +2724,7 @@ func TestUpdateOperationOwnReferenceForCluster(t *testing.T) {
 	genController := func() *Controller {
 		return &Controller{
 			Client:                newFakeClient(),
-			ClientSet:             clientsetfake.NewSimpleClientset(),
+			ClientSet:             clientsetfake.NewClientset(),
 			KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 			KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 			InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
@@ -2813,7 +2813,7 @@ func TestUpdateOperationOwnReferenceForCluster(t *testing.T) {
 func Test_FetchGlobalManifestImageTag(t *testing.T) {
 	controller := Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
@@ -2865,7 +2865,7 @@ func Test_FetchGlobalManifestImageTag(t *testing.T) {
 func TestSetupWithManager(t *testing.T) {
 	controller := Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		KubeanClusterSet:      clusterv1alpha1fake.NewSimpleClientset(),
 		KubeanClusterOpsSet:   clusteroperationv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),

--- a/pkg/controllers/infomanifest/controller_test.go
+++ b/pkg/controllers/infomanifest/controller_test.go
@@ -5,6 +5,7 @@ package infomanifest
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
@@ -55,6 +56,10 @@ func newFakeClient() client.Client {
 	return client
 }
 
+func encodedRepoAuth() string {
+	return base64.StdEncoding.EncodeToString([]byte{'H', 'a', 'r', 'b', 'o', 'r', '1', '2', '3', '4', '5', '\n'})
+}
+
 func fetchTestingFake(obj interface{ RESTClient() rest.Interface }) *k8stesting.Fake {
 	// https://stackoverflow.com/questions/69740891/mocking-errors-with-client-go-fake-client
 	return reflect.Indirect(reflect.ValueOf(obj)).FieldByName("Fake").Interface().(*k8stesting.Fake)
@@ -79,7 +84,7 @@ func removeReactorFromTestingTake(obj interface{ RESTClient() rest.Interface }, 
 func Test_ParseConfigMapToLocalService(t *testing.T) {
 	controller := &Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
 	}
 	localServiceData := `
@@ -135,7 +140,7 @@ func Test_ParseConfigMapToLocalService(t *testing.T) {
 					{
 						ImageRepoAddress: "temp-registry.daocloud.io:5000",
 						UserName:         "admin",
-						PasswordBase64:   "SGFyYm9yMTIzNDUK",
+						PasswordBase64:   encodedRepoAuth(),
 					},
 				},
 				FilesRepo: "http://temp-registry.daocloud.io:9000",
@@ -163,7 +168,7 @@ func Test_ParseConfigMapToLocalService(t *testing.T) {
 func Test_Test_UpdateLocalAvailableImage2(t *testing.T) {
 	controller := &Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
 	}
 
@@ -238,7 +243,7 @@ func Test_Test_UpdateLocalAvailableImage2(t *testing.T) {
 func Test_UpdateLocalAvailableImage(t *testing.T) {
 	controller := &Controller{
 		Client:                newFakeClient(),
-		ClientSet:             clientsetfake.NewSimpleClientset(),
+		ClientSet:             clientsetfake.NewClientset(),
 		InfoManifestClientSet: manifestv1alpha1fake.NewSimpleClientset(),
 	}
 	manifestName := "manifest1"
@@ -315,7 +320,7 @@ func TestIsOnlineENV(t *testing.T) {
 	genController := func() *Controller {
 		return &Controller{
 			Client:                    newFakeClient(),
-			ClientSet:                 clientsetfake.NewSimpleClientset(),
+			ClientSet:                 clientsetfake.NewClientset(),
 			InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 			LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 		}
@@ -367,7 +372,7 @@ func TestIsOnlineENV(t *testing.T) {
 func TestFetchLocalServiceCM(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 	}
@@ -428,7 +433,7 @@ func TestFetchLocalServiceCM(t *testing.T) {
 func TestUpdateLocalService(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 	}
@@ -861,7 +866,7 @@ func TestOp(t *testing.T) {
 func TestReconcile(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 	}
@@ -993,7 +998,7 @@ func TestReconcile(t *testing.T) {
 func TestStart(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 	}
@@ -1005,7 +1010,7 @@ func TestStart(t *testing.T) {
 func TestSetupWithManager(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 	}

--- a/pkg/controllers/offlineversion/controller_test.go
+++ b/pkg/controllers/offlineversion/controller_test.go
@@ -77,7 +77,7 @@ func removeReactorFromTestingTake(obj interface{ RESTClient() rest.Interface }, 
 func TestMergeManifestsStatus(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 	}
@@ -446,7 +446,7 @@ func TestReconcile(t *testing.T) {
 			args: func() bool {
 				controller := &Controller{
 					Client:                    newFakeClient(),
-					ClientSet:                 clientsetfake.NewSimpleClientset(),
+					ClientSet:                 clientsetfake.NewClientset(),
 					LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 					InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 				}
@@ -495,7 +495,7 @@ func TestReconcile(t *testing.T) {
 			args: func() bool {
 				controller := &Controller{
 					Client:                    newFakeClient(),
-					ClientSet:                 clientsetfake.NewSimpleClientset(),
+					ClientSet:                 clientsetfake.NewClientset(),
 					LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 					InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 				}
@@ -535,7 +535,7 @@ func TestReconcile(t *testing.T) {
 			args: func() bool {
 				controller := &Controller{
 					Client:                    newFakeClient(),
-					ClientSet:                 clientsetfake.NewSimpleClientset(),
+					ClientSet:                 clientsetfake.NewClientset(),
 					LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 					InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 				}
@@ -549,7 +549,7 @@ func TestReconcile(t *testing.T) {
 			args: func() bool {
 				controller := &Controller{
 					Client:                    newFakeClient(),
-					ClientSet:                 clientsetfake.NewSimpleClientset(),
+					ClientSet:                 clientsetfake.NewClientset(),
 					LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 					InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 				}
@@ -593,7 +593,7 @@ func TestReconcile(t *testing.T) {
 			args: func() bool {
 				controller := &Controller{
 					Client:                    newFakeClient(),
-					ClientSet:                 clientsetfake.NewSimpleClientset(),
+					ClientSet:                 clientsetfake.NewClientset(),
 					LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 					InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 				}
@@ -627,7 +627,7 @@ func TestReconcile(t *testing.T) {
 			args: func() bool {
 				controller := &Controller{
 					Client:                    newFakeClient(),
-					ClientSet:                 clientsetfake.NewSimpleClientset(),
+					ClientSet:                 clientsetfake.NewClientset(),
 					LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 					InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 				}
@@ -679,7 +679,7 @@ func TestReconcile(t *testing.T) {
 func TestStart(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 	}
@@ -691,7 +691,7 @@ func TestStart(t *testing.T) {
 func TestSetupWithManager(t *testing.T) {
 	controller := &Controller{
 		Client:                    newFakeClient(),
-		ClientSet:                 clientsetfake.NewSimpleClientset(),
+		ClientSet:                 clientsetfake.NewClientset(),
 		LocalArtifactSetClientSet: localartifactsetv1alpha1fake.NewSimpleClientset(),
 		InfoManifestClientSet:     manifestv1alpha1fake.NewSimpleClientset(),
 	}

--- a/pkg/crypto/crypto_test.go
+++ b/pkg/crypto/crypto_test.go
@@ -107,7 +107,7 @@ func TestInitConfiguration(t *testing.T) {
 			if tt.existingCM != nil {
 				objects = append(objects, tt.existingCM)
 			}
-			clientset := fake.NewSimpleClientset(objects...)
+			clientset := fake.NewClientset(objects...)
 
 			// Mock errors if specified
 			if tt.getError != nil {

--- a/pkg/util/cluster_test.go
+++ b/pkg/util/cluster_test.go
@@ -140,7 +140,7 @@ func TestUpdateOwnReference(t *testing.T) {
 		{
 			name: "already ownerReferences exist",
 			args: func() bool {
-				fakeClient := clientsetfake.NewSimpleClientset()
+				fakeClient := clientsetfake.NewClientset()
 				configMapList := []*apis.ConfigMapRef{{Name: "abc", NameSpace: "abc"}}
 				fakeClient.CoreV1().ConfigMaps(configMapList[0].NameSpace).Create(context.Background(), &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -162,7 +162,7 @@ func TestUpdateOwnReference(t *testing.T) {
 		{
 			name: "empty RefData",
 			args: func() bool {
-				fakeClient := clientsetfake.NewSimpleClientset()
+				fakeClient := clientsetfake.NewClientset()
 				configMapList := []*apis.ConfigMapRef{{Name: "", NameSpace: ""}}
 				secretList := []*apis.SecretRef{{Name: "", NameSpace: ""}}
 				return UpdateOwnReference(fakeClient, configMapList, secretList, metav1.OwnerReference{}) == nil
@@ -172,7 +172,7 @@ func TestUpdateOwnReference(t *testing.T) {
 		{
 			name: "not found",
 			args: func() bool {
-				fakeClient := clientsetfake.NewSimpleClientset()
+				fakeClient := clientsetfake.NewClientset()
 				configMapList := []*apis.ConfigMapRef{{Name: "cm1", NameSpace: "abc"}}
 				secretList := []*apis.SecretRef{{Name: "secret1", NameSpace: "abc"}}
 				return UpdateOwnReference(fakeClient, configMapList, secretList, metav1.OwnerReference{}) == nil
@@ -182,7 +182,7 @@ func TestUpdateOwnReference(t *testing.T) {
 		{
 			name: "record exists",
 			args: func() bool {
-				fakeClient := clientsetfake.NewSimpleClientset()
+				fakeClient := clientsetfake.NewClientset()
 				fakeClient.CoreV1().ConfigMaps("abc").Create(context.Background(), &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 					Name:      "cm1",
 					Namespace: "abc",
@@ -209,7 +209,7 @@ func TestUpdateOwnReference(t *testing.T) {
 
 func TestFetchKubeanConfigProperty(t *testing.T) {
 	genClient := func() kubernetes.Interface {
-		return clientsetfake.NewSimpleClientset()
+		return clientsetfake.NewClientset()
 	}
 	tests := []struct {
 		name   string

--- a/pkg/webhooks/clusterops/clusterops_webhook_test.go
+++ b/pkg/webhooks/clusterops/clusterops_webhook_test.go
@@ -186,7 +186,7 @@ func TestEnsureCASecretExist(t *testing.T) {
 		{
 			name: "create certs unsuccessfully",
 			args: func() bool {
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				err := EnsureCASecretExist(fakeClientSet, func() (*corev1.Secret, error) {
 					return nil, fmt.Errorf("failed")
 				})
@@ -197,7 +197,7 @@ func TestEnsureCASecretExist(t *testing.T) {
 		{
 			name: "good case",
 			args: func() bool {
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				err := EnsureCASecretExist(fakeClientSet, createHTTPSCAInSecret)
 				data, _ := fakeClientSet.CoreV1().Secrets(util.GetCurrentNSOrDefault()).Get(context.Background(), CAStoreSecret, metav1.GetOptions{})
 				return err == nil && len(data.Data) == 2
@@ -207,7 +207,7 @@ func TestEnsureCASecretExist(t *testing.T) {
 		{
 			name: "create secret unsuccessfully",
 			args: func() bool {
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				fetchTestingFake(fakeClientSet.CoreV1()).PrependReactor("create", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("create secret but error")
 				})
@@ -240,7 +240,7 @@ func TestUpdateClusterOperationWebhook(t *testing.T) {
 				certsDir = strings.TrimRight(os.TempDir(), "/")
 				ClusterOperationWebhook = "my-webhook-abc"
 				CreateHTTPSCAFilesFromSecret(&corev1.Secret{})
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				EnsureCASecretExist(fakeClientSet, createHTTPSCAInSecret)
 				UpdateClusterOperationWebhook(fakeClientSet)
 				os.Remove(filepath.Join(certsDir, certFile))
@@ -259,7 +259,7 @@ func TestUpdateClusterOperationWebhook(t *testing.T) {
 				defer func() {
 					ClusterOperationWebhook = "kubean-admission-webhook"
 				}()
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				err := UpdateClusterOperationWebhook(fakeClientSet)
 				return err != nil && err.Error() == "ClusterOperationWebhook empty"
 			},
@@ -269,7 +269,7 @@ func TestUpdateClusterOperationWebhook(t *testing.T) {
 			name: "get secret unsuccessfully",
 			arg: func() bool {
 				certsDir = strings.TrimRight(os.TempDir(), "/")
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				EnsureCASecretExist(fakeClientSet, createHTTPSCAInSecret)
 				fetchTestingFake(fakeClientSet.CoreV1()).PrependReactor("get", "secrets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("this is error")
@@ -284,7 +284,7 @@ func TestUpdateClusterOperationWebhook(t *testing.T) {
 			name: "create webhook unsuccessfully",
 			arg: func() bool {
 				certsDir = strings.TrimRight(os.TempDir(), "/")
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				EnsureCASecretExist(fakeClientSet, createHTTPSCAInSecret)
 				fetchTestingFake(fakeClientSet.AdmissionregistrationV1()).PrependReactor("create", "validatingwebhookconfigurations", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("create validatingwebhookconfigurations but error")
@@ -299,7 +299,7 @@ func TestUpdateClusterOperationWebhook(t *testing.T) {
 			name: "update webhook unsuccessfully",
 			arg: func() bool {
 				certsDir = strings.TrimRight(os.TempDir(), "/")
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				EnsureCASecretExist(fakeClientSet, createHTTPSCAInSecret)
 				fetchTestingFake(fakeClientSet.AdmissionregistrationV1()).PrependReactor("update", "validatingwebhookconfigurations", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("update validatingwebhookconfigurations but error")
@@ -317,7 +317,7 @@ func TestUpdateClusterOperationWebhook(t *testing.T) {
 			name: "unnecessarily update webhook when secret is the same",
 			arg: func() bool {
 				certsDir = strings.TrimRight(os.TempDir(), "/")
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				EnsureCASecretExist(fakeClientSet, createHTTPSCAInSecret)
 				fetchTestingFake(fakeClientSet.AdmissionregistrationV1()).PrependReactor("update", "validatingwebhookconfigurations", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("update validatingwebhookconfigurations but error")
@@ -545,7 +545,7 @@ func TestWaitForCASecretExist(t *testing.T) {
 		{
 			name: "good case",
 			args: func() bool {
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				go func() {
 					time.Sleep(time.Second)
 					EnsureCASecretExist(fakeClientSet, createHTTPSCAInSecret)
@@ -574,7 +574,7 @@ func TestCreateHTTPSCASecretWithLock(t *testing.T) {
 		{
 			name: "good case",
 			args: func() bool {
-				fakeClientSet := clientsetfake.NewSimpleClientset()
+				fakeClientSet := clientsetfake.NewClientset()
 				ctx, cancel := context.WithCancel(context.Background())
 				go func() {
 					time.Sleep(time.Second * 2)


### PR DESCRIPTION
<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The golangci-lint version is too low and conflicts with the project golang main version, causing lint CI to fail. 
This PR will fix it.

