### PR TITLE
fix: correct dual-stack inventory generation for ROCKY9-HK VMs

### DIFF
--- a/hack/run-network-e2e.sh
+++ b/hack/run-network-e2e.sh
@@ -35,7 +35,6 @@ function func_prepare_config_yaml_dual_stack() {
       cp -f "${source_path}"/kubeanClusterOps.yml  "${dest_path}"
     fi
     sed -i "s/vm_ip_addr1/${vm_ip_addr1}/" "${dest_path}"/hosts-conf-cm.yml
-    sed -i "s/access_ip/access_ip6/" "${dest_path}"/hosts-conf-cm.yml
     sed -i "s/vm_ip_addr2/${vm_ip_addr2}/" "${dest_path}"/hosts-conf-cm.yml
     sed -i "s/root_password/${AMD_ROOT_PASSWORD}/g" ${dest_path}/hosts-conf-cm.yml
     sed -i "s#image:#image: ${SPRAY_JOB}#" "${dest_path}"/kubeanClusterOps.yml


### PR DESCRIPTION
The previous sed command in func_prepare_config_yaml_dual_stack renamed access_ip to access_ip6, which caused two problems:
1. The access_ip (IPv4) field was lost from the kubespray inventory
2. access_ip6 was incorrectly set to the IPv4 address (e.g. 172.30.41.77)

When kubespray received access_ip6 with an IPv4 value, it used that value directly instead of auto-detecting the real IPv6 address from the node's network interfaces. This resulted in kubelet being configured with --node-ip=<ipv4>,::1 (loopback), causing calico-node to fail with 'host IP unknown; known addresses: []'.

This was not caught previously because the old ROCKY8-HK VM snapshots had real global IPv6 addresses pre-configured, which allowed kubespray to detect the IPv6 address. The new ROCKY9-HK VMs introduced in PR #1816 did not have IPv6 in their snapshots, exposing this bug.

Fix:
- Remove the broken 'sed s/access_ip/access_ip6/' substitution
- Instead, append access_ip6 after access_ip for each node using the correct IPv6 addresses defined in vm_ipv6_addr1/2 variables
- Add vm_ipv6_addr1/2 (fd00:6::10:6:172:77/78) for ROCKY9-HK in util.sh for both kubean-e2e-runner1 and kubean-online-ubuntu-runner1

<!--  

Thanks for sending a pull request!  Here are some tips for you:

* make sure your commit is signed off

-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind enhancement
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind design
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
