### PR TITLE
ci: gate external PR e2e with ok-to-test

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -1,7 +1,7 @@
 name: 3. PR verify
 
 on:
-  pull_request_target:
+  pull_request:
     types:
     - opened
     - synchronize
@@ -26,18 +26,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get_ref:
-    runs-on: ubuntu-latest
-    outputs:
-      ref: ${{ steps.result.outputs.ref }}
-    steps:
-    - name: Get Ref
-      id: result
-      run: |
-        echo ref=${{ github.event.pull_request.head.sha }} >> $GITHUB_OUTPUT
-
   static-check:
-    needs: get_ref
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -46,8 +35,6 @@ jobs:
     - uses: actions/checkout@v7.0.0
       with:
         fetch-depth: 0
-        ref: ${{ needs.get_ref.outputs.ref }}
-        allow-unsafe-pr-checkout: true
 
     - uses: actions/setup-go@v6
       with:
@@ -80,7 +67,7 @@ jobs:
         trivy-config: .trivy.yml
 
   unit-test:
-    needs: [ static-check, get_ref ]
+    needs: static-check
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -90,8 +77,6 @@ jobs:
     - uses: actions/checkout@v7.0.0
       with:
         fetch-depth: 0
-        ref: ${{ needs.get_ref.outputs.ref }}
-        allow-unsafe-pr-checkout: true
 
     - uses: actions/setup-go@v6
       with:
@@ -102,7 +87,7 @@ jobs:
         make test
 
   build-push-for-e2e:
-    needs: [ unit-test, get_ref ]
+    needs: unit-test
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -123,12 +108,6 @@ jobs:
       run: |
         echo "REPO: ${{ env.REPO }}"
         echo "KUBESPRAY_TAG: ${{ env.KUBESPRAY_TAG }}"
-
-    - uses: actions/checkout@v7.0.0
-      with:
-        fetch-depth: 0
-        ref: ${{ needs.get_ref.outputs.ref }}
-        allow-unsafe-pr-checkout: true
 
     - name: Log in to registry
       # This is where you will update the PAT to GITHUB_TOKEN
@@ -195,7 +174,7 @@ jobs:
         docker push $IMAGE_ID:$VERSION
 
   e2e:
-    needs: [ build-push-for-e2e, get_ref ]
+    needs: build-push-for-e2e
     runs-on: [ self-hosted, online ]
     timeout-minutes: 900
     permissions:
@@ -206,8 +185,6 @@ jobs:
     - uses: actions/checkout@v7.0.0
       with:
         fetch-depth: 0
-        ref: ${{ needs.get_ref.outputs.ref }}
-        allow-unsafe-pr-checkout: true
     - uses: actions/setup-go@v6
       with:
         go-version: 1.25.0

--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -9,12 +9,11 @@ on:
     paths-ignore:
     - docs/**
     - examples/**
+  pull_request_target:
+    types:
+    - labeled
 
 env:
-  VSPHERE_USER: ${{ secrets.VSPHERE_USER }}
-  VSPHERE_PASSWD: ${{ secrets.VSPHERE_PASSWD }}
-  AMD_ROOT_PASSWORD: ${{ secrets.AMD_ROOT_PASSWORD }}
-  KYLIN_VM_PASSWORD: ${{ secrets.KYLIN_VM_PASSWORD }}
   KUBEAN_OPERATOR_IMAGE_NAME: kubean-operator
   KUBEAN_ADMISSION_IMAGE_NAME: kubean-admission
   KUBESPRAY_IMAGE_NAME: kubespray
@@ -26,15 +25,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  static-check:
+  authorize:
+    if: github.event_name == 'pull_request' || github.event.label.name == 'ok-to-test'
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      contents: read
+      issues: write
+    outputs:
+      ref: ${{ steps.result.outputs.ref }}
+    steps:
+    - name: Authorize workflow ref
+      id: result
+      env:
+        ACTOR: ${{ github.event.sender.login }}
+        EVENT_NAME: ${{ github.event_name }}
+        GH_TOKEN: ${{ github.token }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        set -euo pipefail
+        if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+          echo "ref=" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        PERMISSION="$(gh api \
+          "/repos/${GITHUB_REPOSITORY}/collaborators/${ACTOR}/permission" \
+          --jq '.permission')"
+        if [[ ! "${PERMISSION}" =~ ^(write|maintain|admin)$ ]]; then
+          echo "::error::${ACTOR} does not have permission to approve privileged E2E"
+          exit 1
+        fi
+        if [[ ! "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::error::PR #${PR_NUMBER} does not have a valid head SHA"
+          exit 1
+        fi
+
+        echo "ref=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+        gh api --method DELETE \
+          "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/ok-to-test" \
+          >/dev/null
+        echo "Approved PR #${PR_NUMBER} at ${HEAD_SHA} for privileged E2E"
+
+  static-check:
+    needs: authorize
+    runs-on: ubuntu-latest
+    permissions:
       contents: read
     steps:
     - uses: actions/checkout@v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
+        ref: ${{ needs.authorize.outputs.ref }}
+        allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
     - uses: actions/setup-go@v6
       with:
@@ -67,16 +111,18 @@ jobs:
         trivy-config: .trivy.yml
 
   unit-test:
-    needs: static-check
+    needs: [ static-check, authorize ]
     runs-on: ubuntu-latest
     permissions:
-      packages: write
       contents: read
 
     steps:
     - uses: actions/checkout@v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
+        ref: ${{ needs.authorize.outputs.ref }}
+        allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
     - uses: actions/setup-go@v6
       with:
@@ -87,7 +133,12 @@ jobs:
         make test
 
   build-push-for-e2e:
-    needs: unit-test
+    if: >-
+      ${{
+        github.event_name == 'pull_request_target' ||
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
+    needs: [ unit-test, authorize ]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -97,6 +148,9 @@ jobs:
     - uses: actions/checkout@v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
+        ref: ${{ needs.authorize.outputs.ref }}
+        allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
     - name: Set env
       run: |
@@ -174,17 +228,25 @@ jobs:
         docker push $IMAGE_ID:$VERSION
 
   e2e:
-    needs: build-push-for-e2e
+    needs: [ build-push-for-e2e, authorize ]
     runs-on: [ self-hosted, online ]
     timeout-minutes: 900
     permissions:
-      packages: write
+      packages: read
       contents: read
+    env:
+      VSPHERE_USER: ${{ secrets.VSPHERE_USER }}
+      VSPHERE_PASSWD: ${{ secrets.VSPHERE_PASSWD }}
+      AMD_ROOT_PASSWORD: ${{ secrets.AMD_ROOT_PASSWORD }}
+      KYLIN_VM_PASSWORD: ${{ secrets.KYLIN_VM_PASSWORD }}
 
     steps:
     - uses: actions/checkout@v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
+        ref: ${{ needs.authorize.outputs.ref }}
+        allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
     - uses: actions/setup-go@v6
       with:
         go-version: 1.25.0

--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -136,7 +136,10 @@ jobs:
     if: >-
       ${{
         github.event_name == 'pull_request_target' ||
-        github.event.pull_request.head.repo.full_name == github.repository
+        (
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.event.pull_request.user.login != 'dependabot[bot]'
+        )
       }}
     needs: [ unit-test, authorize ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- run unprivileged checks for fork PRs with `pull_request`
- skip GHCR publishing and self-hosted E2E for unapproved fork and Dependabot PRs
- run privileged E2E for the exact reviewed PR SHA when a maintainer applies `ok-to-test`
- keep full CI automatic for same-repository, non-Dependabot PRs

## Expected behavior

| PR source | Initial workflow | GHCR push and self-hosted E2E |
| --- | --- | --- |
| Same repository, non-Dependabot | `pull_request` runs the complete workflow | Runs automatically |
| External fork | `pull_request` runs `authorize`, `static-check`, and `unit-test` | Skipped until a maintainer applies `ok-to-test` |
| Dependabot | `pull_request` runs `authorize`, `static-check`, and `unit-test` | Skipped until a maintainer applies `ok-to-test` |
| Approved external or Dependabot PR | `pull_request_target: labeled` uses the workflow from `main` | Runs against the exact SHA captured when `ok-to-test` was applied |

## Safety controls

- require the `ok-to-test` label actor to have `write`, `maintain`, or `admin` permission
- validate and pin the 40-character PR head SHA from the label event
- consume `ok-to-test` immediately as a one-shot approval
- use the trusted workflow definition from the default branch for label events
- disable persisted checkout credentials
- grant package write permission only to the image build job
- expose infrastructure secrets only to the self-hosted E2E job
- use a shared concurrency group so a new PR commit cancels an older run

## Merging this PR

1. Obtain the one approving review required by the `main` branch protection rule.
2. Confirm DCO passes for every commit.
3. Confirm the `pull_request` run passes `authorize`, `static-check`, and `unit-test`, while `build-push-for-e2e` and `e2e` are skipped.
4. Do not rerun the cancelled `pull_request_target` check on this PR. It came from the old workflow currently on `main` and was cancelled before image publishing or E2E.
5. Merge this PR into `main`. The `pull_request_target: labeled` path only becomes active after the workflow is present on the default branch.
6. Keep **Require approval for all external contributors** enabled in the repository Actions settings.

## External fork and Dependabot process after merge

1. Review the PR and any workflow changes before approving its initial Actions run. If GitHub requests workflow approval, approve it only after confirming that the untrusted `pull_request` path does not target self-hosted runners or request privileged credentials.
2. Wait for the initial `authorize`, `static-check`, and `unit-test` jobs to pass. The image build and E2E jobs should remain skipped.
3. Review the latest PR head commit and record its SHA. Pay particular attention to executable CI surfaces such as workflow files, Dockerfiles, Makefiles, build scripts, and `hack/e2e.sh`.
4. A maintainer with `write`, `maintain`, or `admin` permission applies the `ok-to-test` label.
5. The trusted default-branch workflow validates the label actor, captures the event's PR head SHA, removes `ok-to-test`, and reruns static and unit checks against that SHA.
6. After those checks pass, the workflow builds and pushes the E2E images, then runs E2E on the self-hosted runner with the scoped infrastructure secrets.
7. Confirm `authorize`, `static-check`, `unit-test`, `build-push-for-e2e`, and `e2e` all pass for the approved SHA.
8. Obtain the required approving review and merge the PR.

If the PR receives another commit after approval, the new `pull_request` run cancels the older privileged run. Review the new SHA and apply `ok-to-test` again. Because the label is one-shot, it must also be reapplied after a failed or manually cancelled privileged run.

## Operational limitations

- The repository currently has no required status checks. The E2E process is therefore a maintainer-enforced policy rather than a GitHub-enforced merge gate.
- The self-hosted runner must remain isolated or be restricted to trusted default-branch workflows. Fork workflow approval alone does not prevent a contributor from editing a `pull_request` workflow to target an unrestricted self-hosted runner. Do not approve such workflow changes.

## Validation

- fork PR run passed `authorize`, `static-check`, and `unit-test`; privileged jobs were skipped: https://github.com/kubean-io/kubean/actions/runs/32087557642
- DCO passed for the current head commit