### PR TITLE
ci: trust ok-to-test label permissions

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -49,13 +49,6 @@ jobs:
           exit 0
         fi
 
-        PERMISSION="$(gh api \
-          "/repos/${GITHUB_REPOSITORY}/collaborators/${ACTOR}/permission" \
-          --jq '.permission')"
-        if [[ ! "${PERMISSION}" =~ ^(write|maintain|admin)$ ]]; then
-          echo "::error::${ACTOR} does not have permission to approve privileged E2E"
-          exit 1
-        fi
         if [[ ! "${HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
           echo "::error::PR #${PR_NUMBER} does not have a valid head SHA"
           exit 1
@@ -65,7 +58,7 @@ jobs:
         gh api --method DELETE \
           "/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels/ok-to-test" \
           >/dev/null
-        echo "Approved PR #${PR_NUMBER} at ${HEAD_SHA} for privileged E2E"
+        echo "${ACTOR} approved PR #${PR_NUMBER} at ${HEAD_SHA} for privileged E2E"
 
   static-check:
     needs: authorize


### PR DESCRIPTION
## Summary

- remove the collaborator permission API check from the `authorize` step
- rely on GitHub's existing permission checks for applying the `ok-to-test` label
- retain actor audit logging, the 40-character head SHA validation, one-time label removal, and fixed-SHA workflow output

## Context

This fixes the HTTP 403 (`Resource not accessible by integration`) observed during the real-world test in #1842, where run 32091572464 attempted to query the label actor's collaborator permission with `GITHUB_TOKEN`.

GitHub users with the Triage role can also apply labels. The operational constraint for this approach is therefore: do not grant Triage to users who should not be allowed to authorize privileged E2E. The repository currently has no users with Triage access.

## Validation

- parsed `.github/workflows/auto-pr-ci.yaml` with the existing PyYAML installation and verified the authorize invariants
- `git diff --check`