### PR TITLE
ci: allow consuming ok-to-test on pull requests

### DIFF
--- a/.github/workflows/auto-pr-ci.yaml
+++ b/.github/workflows/auto-pr-ci.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     outputs:
       ref: ${{ steps.result.outputs.ref }}
     steps:


### PR DESCRIPTION
## What this PR does

A second `403 Resource not accessible by integration` was observed in `pull_request_target` run 32093677588 after #1843 removed the collaborator permission API call. The HEAD SHA validation passed, but the authorize job failed while deleting the `ok-to-test` label from the pull request.

Because the labeled object is a pull request, deleting its label requires `pull-requests: write`, not `issues: write`. This PR makes only that minimal authorize-job permission change while retaining `contents: read`; no scripts or other jobs are changed.
